### PR TITLE
fix: raise gRPC client message limits for workspace RPCs

### DIFF
--- a/crates/forge_repo/src/context_engine.rs
+++ b/crates/forge_repo/src/context_engine.rs
@@ -9,7 +9,7 @@ use forge_domain::{
     WorkspaceInfo,
 };
 
-use crate::proto_generated::forge_service_client::ForgeServiceClient;
+use crate::new_forge_service_client;
 use crate::proto_generated::{self, *};
 
 // TryFrom implementations for converting proto types to domain types
@@ -117,7 +117,7 @@ impl<I> ForgeContextEngineRepository<I> {
 impl<I: GrpcInfra> WorkspaceIndexRepository for ForgeContextEngineRepository<I> {
     async fn authenticate(&self) -> Result<WorkspaceAuth> {
         let channel = self.infra.channel();
-        let mut client = ForgeServiceClient::new(channel);
+        let mut client = new_forge_service_client(channel);
         let request = tonic::Request::new(CreateApiKeyRequest { user_id: None });
 
         let response = client
@@ -144,7 +144,7 @@ impl<I: GrpcInfra> WorkspaceIndexRepository for ForgeContextEngineRepository<I> 
         let request = self.with_auth(request, auth_token)?;
 
         let channel = self.infra.channel();
-        let mut client = ForgeServiceClient::new(channel);
+        let mut client = new_forge_service_client(channel);
         let response = client.create_workspace(request).await?.into_inner();
 
         response.try_into()
@@ -174,7 +174,7 @@ impl<I: GrpcInfra> WorkspaceIndexRepository for ForgeContextEngineRepository<I> 
         let request = self.with_auth(request, auth_token)?;
 
         let channel = self.infra.channel();
-        let mut client = ForgeServiceClient::new(channel);
+        let mut client = new_forge_service_client(channel);
         let response = client.upload_files(request).await?;
 
         let result = response
@@ -213,7 +213,7 @@ impl<I: GrpcInfra> WorkspaceIndexRepository for ForgeContextEngineRepository<I> 
         let request = self.with_auth(request, auth_token)?;
 
         let channel = self.infra.channel();
-        let mut client = ForgeServiceClient::new(channel);
+        let mut client = new_forge_service_client(channel);
         let response = client.search(request).await?;
 
         let result = response.into_inner().result.unwrap_or_default();
@@ -284,7 +284,7 @@ impl<I: GrpcInfra> WorkspaceIndexRepository for ForgeContextEngineRepository<I> 
         let request = self.with_auth(request, auth_token)?;
 
         let channel = self.infra.channel();
-        let mut client = ForgeServiceClient::new(channel);
+        let mut client = new_forge_service_client(channel);
         let response = client.list_workspaces(request).await?;
 
         response
@@ -307,7 +307,7 @@ impl<I: GrpcInfra> WorkspaceIndexRepository for ForgeContextEngineRepository<I> 
         let request = self.with_auth(request, auth_token)?;
 
         let channel = self.infra.channel();
-        let mut client = ForgeServiceClient::new(channel);
+        let mut client = new_forge_service_client(channel);
         let response = client.get_workspace_info(request).await?;
 
         let workspace = response.into_inner().workspace;
@@ -329,7 +329,7 @@ impl<I: GrpcInfra> WorkspaceIndexRepository for ForgeContextEngineRepository<I> 
         let request = self.with_auth(request, auth_token)?;
 
         let channel = self.infra.channel();
-        let mut client = ForgeServiceClient::new(channel);
+        let mut client = new_forge_service_client(channel);
         let response = client.list_files(request).await?;
 
         response
@@ -360,7 +360,7 @@ impl<I: GrpcInfra> WorkspaceIndexRepository for ForgeContextEngineRepository<I> 
         let request = self.with_auth(request, auth_token)?;
 
         let channel = self.infra.channel();
-        let mut client = ForgeServiceClient::new(channel);
+        let mut client = new_forge_service_client(channel);
         client.delete_files(request).await?;
 
         Ok(())
@@ -378,7 +378,7 @@ impl<I: GrpcInfra> WorkspaceIndexRepository for ForgeContextEngineRepository<I> 
         let request = self.with_auth(request, auth_token)?;
 
         let channel = self.infra.channel();
-        let mut client = ForgeServiceClient::new(channel);
+        let mut client = new_forge_service_client(channel);
         client.delete_workspace(request).await?;
 
         Ok(())

--- a/crates/forge_repo/src/fuzzy_search.rs
+++ b/crates/forge_repo/src/fuzzy_search.rs
@@ -5,8 +5,8 @@ use async_trait::async_trait;
 use forge_app::GrpcInfra;
 use forge_domain::{FuzzySearchRepository, SearchMatch};
 
+use crate::new_forge_service_client;
 use crate::proto_generated::FuzzySearchRequest;
-use crate::proto_generated::forge_service_client::ForgeServiceClient;
 
 /// gRPC implementation of FuzzySearchRepository
 pub struct ForgeFuzzySearchRepository<I> {
@@ -40,7 +40,7 @@ impl<I: GrpcInfra> FuzzySearchRepository for ForgeFuzzySearchRepository<I> {
 
         // Call gRPC API
         let channel = self.infra.channel();
-        let mut client = ForgeServiceClient::new(channel);
+        let mut client = new_forge_service_client(channel);
         let response = client
             .fuzzy_search(request)
             .await

--- a/crates/forge_repo/src/lib.rs
+++ b/crates/forge_repo/src/lib.rs
@@ -1,3 +1,5 @@
+use tonic::transport::Channel;
+
 mod agent;
 mod agent_definition;
 mod context_engine;
@@ -12,6 +14,21 @@ mod validation;
 
 mod proto_generated {
     tonic::include_proto!("forge.v1");
+}
+
+const MAX_GRPC_MESSAGE_SIZE_BYTES: usize = 64 * 1024 * 1024;
+
+/// Creates a ForgeService gRPC client with elevated message-size limits.
+///
+/// # Arguments
+///
+/// * `channel` - Shared gRPC transport channel for ForgeService RPCs
+pub(crate) fn new_forge_service_client(
+    channel: Channel,
+) -> proto_generated::forge_service_client::ForgeServiceClient<Channel> {
+    proto_generated::forge_service_client::ForgeServiceClient::new(channel)
+        .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE_BYTES)
+        .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE_BYTES)
 }
 
 // Only expose forge_repo container

--- a/crates/forge_repo/src/validation.rs
+++ b/crates/forge_repo/src/validation.rs
@@ -7,7 +7,7 @@ use forge_app::GrpcInfra;
 use forge_domain::{SyntaxError, ValidationRepository};
 use tracing::{debug, warn};
 
-use crate::proto_generated::forge_service_client::ForgeServiceClient;
+use crate::new_forge_service_client;
 use crate::proto_generated::{self, File, ValidateFilesRequest};
 
 /// gRPC implementation of ValidationRepository
@@ -43,7 +43,7 @@ impl<I: GrpcInfra> ValidationRepository for ForgeValidationRepository<I> {
 
         // Call gRPC API
         let channel = self.infra.channel();
-        let mut client = ForgeServiceClient::new(channel);
+        let mut client = new_forge_service_client(channel);
         let response = client
             .validate_files(request)
             .await


### PR DESCRIPTION
## Summary
Raise the Forge gRPC client message-size limits in `forge_repo` so workspace commands can handle larger `ListFiles` responses without failing at the default 4 MiB decode limit.

## Context
Workspace commands such as `forge workspace status` and `forge workspace info` were failing on large repositories because the client decoded the full remote file list from a unary `ListFiles` response and hit tonic's default message-size cap. This was reproducible against the `forgecode` repository itself and tracked in issue #2786.

## Changes
- Added a shared `new_forge_service_client` helper in `forge_repo` that applies 64 MiB decode and encode limits to `ForgeServiceClient`
- Updated the workspace context-engine repository to use that helper for all ForgeService RPCs
- Updated the validation and fuzzy-search repositories to use the same client factory so ForgeService client construction is consistent across the crate

### Key Implementation Details
The change is centralized in `crates/forge_repo/src/lib.rs`, which now owns the message-size configuration for `ForgeServiceClient`. The workspace file-listing path in `crates/forge_repo/src/context_engine.rs` now uses the configured client before calling `list_files`, which avoids the oversized-response failure that previously broke workspace status and info.

This PR intentionally focuses on the immediate transport-level fix. The API still returns the full file list in one unary response, so pagination or streaming remains a longer-term follow-up.

## Use Cases
- Run `forge workspace status .` in large repositories without hitting the 4 MiB gRPC decode error
- Run `forge workspace info .` when workspace status needs to compare against a large remote file inventory
- Keep other ForgeService client call sites aligned with the same message-size configuration

## Testing
```bash
cargo check -p forge_repo
cargo test -p forge_repo --lib
cargo run -- workspace status .
cargo run -- workspace info .
```

## Links
- Related issues: #2786
