### PR TITLE
refactor: walk intermediate directories for AGENTS.md discovery

### DIFF
--- a/crates/forge_services/src/instructions.rs
+++ b/crates/forge_services/src/instructions.rs
@@ -3,11 +3,20 @@ use std::sync::Arc;
 
 use forge_app::{CommandInfra, CustomInstructionsService, EnvironmentInfra, FileReaderInfra};
 
-/// This service looks for AGENTS.md files in three locations in order of
-/// priority:
-/// 1. Base path (environment.base_path)
-/// 2. Git root directory (if available)
-/// 3. Current working directory (environment.cwd)
+/// Discovers and loads `AGENTS.md` instruction files from multiple locations,
+/// ordered from broadest to most specific scope:
+///
+/// 1. **Global** — `~/.forge/AGENTS.md`
+/// 2. **Git root to CWD walk** — `AGENTS.md` in every directory from the git
+///    repository root down through each intermediate directory to the current
+///    working directory (inclusive). This enables layered instructions in
+///    monorepos and nested project structures.
+/// 3. **Fallback** — When no git root is available (or CWD is outside the git
+///    root), only the global path and `<CWD>/AGENTS.md` are checked.
+///
+/// All discovered files are accumulated (not overridden). Missing files are
+/// silently skipped. Results are cached for the lifetime of the service
+/// instance.
 #[derive(Clone)]
 pub struct ForgeCustomInstructionsService<F> {
     infra: Arc<F>,
@@ -20,30 +29,12 @@ impl<F: EnvironmentInfra + FileReaderInfra + CommandInfra> ForgeCustomInstructio
     }
 
     async fn discover_agents_files(&self) -> Vec<PathBuf> {
-        let mut paths = Vec::new();
         let environment = self.infra.get_environment();
+        let global_path = environment.global_agentsmd_path();
+        let cwd = environment.cwd.clone();
+        let git_root = self.get_git_root().await;
 
-        // Base custom instructions
-        let base_agent_md = environment.global_agentsmd_path();
-        if !paths.contains(&base_agent_md) {
-            paths.push(base_agent_md);
-        }
-
-        // Repo custom instructions
-        if let Some(git_root_path) = self.get_git_root().await {
-            let git_agent_md = git_root_path.join("AGENTS.md");
-            if !paths.contains(&git_agent_md) {
-                paths.push(git_agent_md);
-            }
-        }
-
-        // Working dir custom instructions
-        let cwd_agent_md = environment.local_agentsmd_path();
-        if !paths.contains(&cwd_agent_md) {
-            paths.push(cwd_agent_md);
-        }
-
-        paths
+        build_instruction_paths(&global_path, git_root.as_ref(), &cwd)
     }
 
     async fn get_git_root(&self) -> Option<PathBuf> {
@@ -80,11 +71,160 @@ impl<F: EnvironmentInfra + FileReaderInfra + CommandInfra> ForgeCustomInstructio
     }
 }
 
+/// Builds the ordered list of `AGENTS.md` paths to check.
+///
+/// Starts with the global path, then walks every directory from `git_root`
+/// down to `cwd` (inclusive). Falls back to global + cwd when no git root is
+/// available or when cwd is not under the git root.
+fn build_instruction_paths(
+    global_path: &PathBuf,
+    git_root: Option<&PathBuf>,
+    cwd: &PathBuf,
+) -> Vec<PathBuf> {
+    let mut paths = vec![global_path.clone()];
+
+    if let Some(git_root) = git_root {
+        if let Ok(relative) = cwd.strip_prefix(git_root) {
+            // Walk from git root through each intermediate directory down to
+            // CWD.
+            let mut current = git_root.clone();
+            push_if_absent(&mut paths, current.join("AGENTS.md"));
+
+            for component in relative.components() {
+                current.push(component);
+                push_if_absent(&mut paths, current.join("AGENTS.md"));
+            }
+        } else {
+            // CWD is outside git root — fall back to CWD only
+            push_if_absent(&mut paths, cwd.join("AGENTS.md"));
+        }
+    } else {
+        // No git root (not in a repo) — fall back to CWD only
+        push_if_absent(&mut paths, cwd.join("AGENTS.md"));
+    }
+
+    paths
+}
+
+/// Pushes `path` into `paths` only if it is not already present.
+fn push_if_absent(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if !paths.contains(&path) {
+        paths.push(path);
+    }
+}
+
 #[async_trait::async_trait]
 impl<F: EnvironmentInfra + FileReaderInfra + CommandInfra> CustomInstructionsService
     for ForgeCustomInstructionsService<F>
 {
     async fn get_custom_instructions(&self) -> Vec<String> {
         self.cache.get_or_init(|| self.init()).await.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use pretty_assertions::assert_eq;
+
+    use super::build_instruction_paths;
+
+    #[test]
+    fn test_walk_intermediate_directories() {
+        let global = PathBuf::from("/home/user/.forge/AGENTS.md");
+        let git_root = PathBuf::from("/repo");
+        let cwd = PathBuf::from("/repo/packages/app");
+
+        let actual = build_instruction_paths(&global, Some(&git_root), &cwd);
+        let expected = vec![
+            PathBuf::from("/home/user/.forge/AGENTS.md"),
+            PathBuf::from("/repo/AGENTS.md"),
+            PathBuf::from("/repo/packages/AGENTS.md"),
+            PathBuf::from("/repo/packages/app/AGENTS.md"),
+        ];
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_cwd_equals_git_root() {
+        let global = PathBuf::from("/home/user/.forge/AGENTS.md");
+        let git_root = PathBuf::from("/repo");
+        let cwd = PathBuf::from("/repo");
+
+        let actual = build_instruction_paths(&global, Some(&git_root), &cwd);
+        let expected = vec![
+            PathBuf::from("/home/user/.forge/AGENTS.md"),
+            PathBuf::from("/repo/AGENTS.md"),
+        ];
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_no_git_root() {
+        let global = PathBuf::from("/home/user/.forge/AGENTS.md");
+        let cwd = PathBuf::from("/some/directory");
+
+        let actual = build_instruction_paths(&global, None, &cwd);
+        let expected = vec![
+            PathBuf::from("/home/user/.forge/AGENTS.md"),
+            PathBuf::from("/some/directory/AGENTS.md"),
+        ];
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_cwd_outside_git_root() {
+        let global = PathBuf::from("/home/user/.forge/AGENTS.md");
+        let git_root = PathBuf::from("/repo");
+        let cwd = PathBuf::from("/other/directory");
+
+        let actual = build_instruction_paths(&global, Some(&git_root), &cwd);
+        let expected = vec![
+            PathBuf::from("/home/user/.forge/AGENTS.md"),
+            PathBuf::from("/other/directory/AGENTS.md"),
+        ];
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_deeply_nested_cwd() {
+        let global = PathBuf::from("/home/user/.forge/AGENTS.md");
+        let git_root = PathBuf::from("/repo");
+        let cwd = PathBuf::from("/repo/a/b/c/d/e");
+
+        let actual = build_instruction_paths(&global, Some(&git_root), &cwd);
+        let expected = vec![
+            PathBuf::from("/home/user/.forge/AGENTS.md"),
+            PathBuf::from("/repo/AGENTS.md"),
+            PathBuf::from("/repo/a/AGENTS.md"),
+            PathBuf::from("/repo/a/b/AGENTS.md"),
+            PathBuf::from("/repo/a/b/c/AGENTS.md"),
+            PathBuf::from("/repo/a/b/c/d/AGENTS.md"),
+            PathBuf::from("/repo/a/b/c/d/e/AGENTS.md"),
+        ];
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_global_path_dedup_when_equals_git_root() {
+        // Edge case: global base_path happens to be the git root
+        let global = PathBuf::from("/repo/AGENTS.md");
+        let git_root = PathBuf::from("/repo");
+        let cwd = PathBuf::from("/repo/packages/app");
+
+        let actual = build_instruction_paths(&global, Some(&git_root), &cwd);
+        let expected = vec![
+            PathBuf::from("/repo/AGENTS.md"),
+            PathBuf::from("/repo/packages/AGENTS.md"),
+            PathBuf::from("/repo/packages/app/AGENTS.md"),
+        ];
+
+        assert_eq!(actual, expected);
     }
 }


### PR DESCRIPTION
## Summary

Walk every intermediate directory from git root to CWD when discovering `AGENTS.md` files, enabling layered per-directory instructions in monorepos and nested project structures.

## Context

Previously, the custom instructions service checked exactly three fixed locations for `AGENTS.md`: the global path (`~/.forge/AGENTS.md`), the git root, and the current working directory. This meant that in a monorepo like `/repo/packages/app`, an `AGENTS.md` placed at `/repo/packages/AGENTS.md` would be silently ignored — only the root and leaf were checked.

This change makes the discovery walk every directory from git root down to CWD so that each layer of the directory tree can contribute its own instructions.

## Changes

- Replaced the fixed three-location lookup in `discover_agents_files` with a directory-walking approach
- Extracted the pure `build_instruction_paths()` function that computes the ordered list of paths without any I/O, making the logic easy to test in isolation
- Added `push_if_absent` helper for deduplication across global, git root, and intermediate paths
- Updated struct-level and function-level documentation to reflect the new behavior

### Key Implementation Details

The walk uses `Path::strip_prefix` to compute the relative path from git root to CWD, then iterates over each component, appending `AGENTS.md` at every level. Fallback behavior is preserved: when no git root is available (or CWD is outside the git root), only the global path and `<CWD>/AGENTS.md` are checked.

## Use Cases

- **Monorepo layering**: Place a shared `AGENTS.md` at `/repo/packages/` that applies to all packages, with per-package overrides in `/repo/packages/app/`
- **Nested projects**: Deeply nested directories inherit instructions from every ancestor up to the repo root
- **Backward compatible**: Existing setups with `AGENTS.md` only at the root and CWD continue to work identically

## Testing

Six unit tests cover the key scenarios:

```bash
cargo test -p forge_services -- instructions::tests
```

| Test | Scenario |
|------|----------|
| `test_walk_intermediate_directories` | Standard monorepo walk |
| `test_cwd_equals_git_root` | CWD is the git root |
| `test_no_git_root` | Not inside a git repository |
| `test_cwd_outside_git_root` | CWD outside the git root |
| `test_deeply_nested_cwd` | 5 levels deep |
| `test_global_path_dedup_when_equals_git_root` | Global path coincides with git root |
