### PR TITLE
fix: add Xiaomi MiMo provider support

### DIFF
--- a/crates/forge_domain/src/provider.rs
+++ b/crates/forge_domain/src/provider.rs
@@ -75,6 +75,7 @@ impl ProviderId {
     pub const NOVITA: ProviderId = ProviderId(Cow::Borrowed("novita"));
     pub const GOOGLE_AI_STUDIO: ProviderId = ProviderId(Cow::Borrowed("google_ai_studio"));
     pub const MODAL: ProviderId = ProviderId(Cow::Borrowed("modal"));
+    pub const XIAOMI_MIMO: ProviderId = ProviderId(Cow::Borrowed("xiaomi_mimo"));
 
     /// Returns all built-in provider IDs
     ///
@@ -110,6 +111,7 @@ impl ProviderId {
             ProviderId::NOVITA,
             ProviderId::GOOGLE_AI_STUDIO,
             ProviderId::MODAL,
+            ProviderId::XIAOMI_MIMO,
         ]
     }
 
@@ -139,6 +141,7 @@ impl ProviderId {
             "novita" => "Novita".to_string(),
             "google_ai_studio" => "GoogleAIStudio".to_string(),
             "modal" => "Modal".to_string(),
+            "xiaomi_mimo" => "XiaomiMimo".to_string(),
             _ => {
                 // For other providers, use UpperCamelCase conversion
                 use convert_case::{Case, Casing};
@@ -186,6 +189,7 @@ impl std::str::FromStr for ProviderId {
             "novita" => ProviderId::NOVITA,
             "google_ai_studio" => ProviderId::GOOGLE_AI_STUDIO,
             "modal" => ProviderId::MODAL,
+            "xiaomi_mimo" => ProviderId::XIAOMI_MIMO,
             // For custom providers, use Cow::Owned to avoid memory leaks
             custom => ProviderId(Cow::Owned(custom.to_string())),
         };
@@ -616,6 +620,24 @@ mod tests {
     fn test_modal_in_built_in_providers() {
         let built_in = ProviderId::built_in_providers();
         assert!(built_in.contains(&ProviderId::MODAL));
+    }
+
+    #[test]
+    fn test_xiaomi_mimo_from_str() {
+        let actual = ProviderId::from_str("xiaomi_mimo").unwrap();
+        let expected = ProviderId::XIAOMI_MIMO;
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_xiaomi_mimo_display_name() {
+        assert_eq!(ProviderId::XIAOMI_MIMO.to_string(), "XiaomiMimo");
+    }
+
+    #[test]
+    fn test_xiaomi_mimo_in_built_in_providers() {
+        let built_in = ProviderId::built_in_providers();
+        assert!(built_in.contains(&ProviderId::XIAOMI_MIMO));
     }
 
     #[test]

--- a/crates/forge_domain/src/provider.rs
+++ b/crates/forge_domain/src/provider.rs
@@ -77,6 +77,7 @@ impl ProviderId {
     pub const GOOGLE_AI_STUDIO: ProviderId = ProviderId(Cow::Borrowed("google_ai_studio"));
     pub const MODAL: ProviderId = ProviderId(Cow::Borrowed("modal"));
     pub const ADAL: ProviderId = ProviderId(Cow::Borrowed("adal"));
+    pub const XIAOMI_MIMO: ProviderId = ProviderId(Cow::Borrowed("xiaomi_mimo"));
 
     /// Returns all built-in provider IDs
     ///
@@ -114,6 +115,7 @@ impl ProviderId {
             ProviderId::GOOGLE_AI_STUDIO,
             ProviderId::MODAL,
             ProviderId::ADAL,
+            ProviderId::XIAOMI_MIMO,
         ]
     }
 
@@ -145,6 +147,7 @@ impl ProviderId {
             "google_ai_studio" => "GoogleAIStudio".to_string(),
             "modal" => "Modal".to_string(),
             "adal" => "AdaL".to_string(),
+            "xiaomi_mimo" => "XiaomiMimo".to_string(),
             _ => {
                 // For other providers, use UpperCamelCase conversion
                 use convert_case::{Case, Casing};
@@ -197,6 +200,7 @@ impl std::str::FromStr for ProviderId {
             "google_ai_studio" => ProviderId::GOOGLE_AI_STUDIO,
             "modal" => ProviderId::MODAL,
             "adal" => ProviderId::ADAL,
+            "xiaomi_mimo" => ProviderId::XIAOMI_MIMO,
             // For custom providers, use Cow::Owned to avoid memory leaks
             custom => ProviderId(Cow::Owned(custom.to_string())),
         };
@@ -654,6 +658,24 @@ mod tests {
     fn test_adal_in_built_in_providers() {
         let built_in = ProviderId::built_in_providers();
         assert!(built_in.contains(&ProviderId::ADAL));
+    }
+
+    #[test]
+    fn test_xiaomi_mimo_from_str() {
+        let actual = ProviderId::from_str("xiaomi_mimo").unwrap();
+        let expected = ProviderId::XIAOMI_MIMO;
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_xiaomi_mimo_display_name() {
+        assert_eq!(ProviderId::XIAOMI_MIMO.to_string(), "XiaomiMimo");
+    }
+
+    #[test]
+    fn test_xiaomi_mimo_in_built_in_providers() {
+        let built_in = ProviderId::built_in_providers();
+        assert!(built_in.contains(&ProviderId::XIAOMI_MIMO));
     }
 
     #[test]

--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -3229,5 +3229,46 @@
       }
     ],
     "auth_methods": ["api_key"]
+  },
+  {
+    "id": "xiaomi_mimo",
+    "api_key_vars": "XIAOMI_MIMO_API_KEY",
+    "url_param_vars": [
+      { "name": "CLUSTER", "options": ["token-plan-sgp.xiaomimimo.com", "token-plan-cn.xiaomimimo.com", "token-plan-ams.xiaomimimo.com"] }
+    ],
+    "response_type": "OpenAI",
+    "url": "https://{{#if CLUSTER}}{{CLUSTER}}{{else}}token-plan-sgp.xiaomimimo.com{{/if}}/v1/chat/completions",
+    "models": [
+      {
+        "id": "mimo-v2-pro",
+        "name": "MiMo V2 Pro",
+        "description": "Xiaomi's flagship foundation model with 1T+ parameters and 1M context length",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "mimo-v2-omni",
+        "name": "MiMo V2 Omni",
+        "description": "Xiaomi's omni-modal model that natively processes image, video, and audio inputs",
+        "context_length": 262100,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "mimo-v2-tts",
+        "name": "MiMo V2 TTS",
+        "description": "Xiaomi's text-to-speech model",
+        "context_length": 8192,
+        "tools_supported": false,
+        "supports_parallel_tool_calls": false,
+        "input_modalities": ["text"]
+      }
+    ],
+    "auth_methods": ["api_key"]
   }
 ]

--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -3419,6 +3419,26 @@
     "url": "https://{{#if CLUSTER}}{{CLUSTER}}{{else}}token-plan-sgp.xiaomimimo.com{{/if}}/v1/chat/completions",
     "models": [
       {
+        "id": "mimo-v2.5-pro",
+        "name": "MiMo V2.5 Pro",
+        "description": "Xiaomi's latest flagship foundation model with enhanced reasoning and agent capabilities",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "mimo-v2.5",
+        "name": "MiMo V2.5",
+        "description": "Xiaomi's balanced V2.5 model for general-purpose tasks",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
         "id": "mimo-v2-pro",
         "name": "MiMo V2 Pro",
         "description": "Xiaomi's flagship foundation model with 1T+ parameters and 1M context length",
@@ -3439,12 +3459,13 @@
         "input_modalities": ["text", "image"]
       },
       {
-        "id": "mimo-v2-tts",
-        "name": "MiMo V2 TTS",
-        "description": "Xiaomi's text-to-speech model",
-        "context_length": 8192,
-        "tools_supported": false,
-        "supports_parallel_tool_calls": false,
+        "id": "mimo-v2-flash",
+        "name": "MiMo V2 Flash",
+        "description": "Xiaomi's fast and efficient model for high-throughput applications",
+        "context_length": 262100,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": false,
         "input_modalities": ["text"]
       }
     ],

--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -3408,5 +3408,46 @@
     "url": "https://api.sylph.ai/v1/chat/completions",
     "models": "https://api.sylph.ai/v1/models",
     "auth_methods": ["api_key"]
+  },
+  {
+    "id": "xiaomi_mimo",
+    "api_key_vars": "XIAOMI_MIMO_API_KEY",
+    "url_param_vars": [
+      { "name": "CLUSTER", "options": ["token-plan-sgp.xiaomimimo.com", "token-plan-cn.xiaomimimo.com", "token-plan-ams.xiaomimimo.com"] }
+    ],
+    "response_type": "OpenAI",
+    "url": "https://{{#if CLUSTER}}{{CLUSTER}}{{else}}token-plan-sgp.xiaomimimo.com{{/if}}/v1/chat/completions",
+    "models": [
+      {
+        "id": "mimo-v2-pro",
+        "name": "MiMo V2 Pro",
+        "description": "Xiaomi's flagship foundation model with 1T+ parameters and 1M context length",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "mimo-v2-omni",
+        "name": "MiMo V2 Omni",
+        "description": "Xiaomi's omni-modal model that natively processes image, video, and audio inputs",
+        "context_length": 262100,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "mimo-v2-tts",
+        "name": "MiMo V2 TTS",
+        "description": "Xiaomi's text-to-speech model",
+        "context_length": 8192,
+        "tools_supported": false,
+        "supports_parallel_tool_calls": false,
+        "input_modalities": ["text"]
+      }
+    ],
+    "auth_methods": ["api_key"]
   }
 ]

--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -3457,16 +3457,6 @@
         "supports_parallel_tool_calls": true,
         "supports_reasoning": true,
         "input_modalities": ["text", "image"]
-      },
-      {
-        "id": "mimo-v2-flash",
-        "name": "MiMo V2 Flash",
-        "description": "Xiaomi's fast and efficient model for high-throughput applications",
-        "context_length": 262100,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": false,
-        "input_modalities": ["text"]
       }
     ],
     "auth_methods": ["api_key"]


### PR DESCRIPTION
## Summary
Add Xiaomi MiMo as a new AI provider with support for MiMo V2 Pro, V2 Omni, and V2 TTS models.

## Context
Xiaomi MiMo is a new AI provider offering high-performance models with competitive capabilities. Adding this provider expands the available AI options for users, particularly for those in Asia-Pacific regions with dedicated cluster endpoints.

## Changes
- Added `XIAOMI_MIMO` provider constant to `ProviderId` enum
- Included Xiaomi MiMo in built-in providers list
- Added display name mapping for "xiaomi_mimo" -> "XiaomiMimo"
- Added parser support for "xiaomi_mimo" string
- Added provider configuration with 3 models:
  - **MiMo V2 Pro**: 1T+ parameters, 1M context length, supports tools and reasoning
  - **MiMo V2 Omni**: Multi-modal (text + image), 262K context, supports tools and reasoning
  - **MiMo V2 TTS**: Text-to-speech model, 8K context
- Configured multi-region API endpoints (Singapore, China, Amsterdam)
- Added unit tests for provider parsing, display name, and built-in list inclusion

### Key Implementation Details
- API key configured via `XIAOMI_MIMO_API_KEY` environment variable
- Dynamic cluster URL selection via `CLUSTER` parameter (defaults to Singapore)
- Response type compatible with OpenAI format
- Models support parallel tool calls and reasoning where applicable

## Use Cases
- Users can now select Xiaomi MiMo models for AI-assisted coding tasks
- Multi-modal support via MiMo V2 Omni for image-based workflows
- Text-to-speech capabilities via MiMo V2 TTS for audio output
- Regional endpoint selection for improved latency in Asia-Pacific

## Testing
```bash
# Run provider tests
cargo test -p forge_domain provider::tests

# Run all tests to verify no regressions
cargo test
```

## Links
- Xiaomi MiMo documentation: https://xiaomimimo.com