### PR TITLE
fix(provider): preserve custom header overrides

### DIFF
--- a/crates/forge_infra/src/http.rs
+++ b/crates/forge_infra/src/http.rs
@@ -202,7 +202,7 @@ impl<F: forge_app::FileWriterInfra + 'static> ForgeHttpInfra<F> {
                 "HTTP-Referer",
                 HeaderValue::from_static("https://forgecode.dev"),
             );
-        };
+        }
         headers.insert(
             reqwest::header::CONNECTION,
             HeaderValue::from_static("keep-alive"),

--- a/crates/forge_infra/src/http.rs
+++ b/crates/forge_infra/src/http.rs
@@ -185,20 +185,24 @@ impl<F: forge_app::FileWriterInfra + 'static> ForgeHttpInfra<F> {
     // - `X-Title`: Sets/modifies your app's title
     fn headers(&self, headers: Option<HeaderMap>) -> HeaderMap {
         let mut headers = headers.unwrap_or_default();
-        // Only set User-Agent if the provider hasn't already set one
+        // Only set Forge defaults if the provider hasn't already set them.
         if !headers.contains_key("User-Agent") {
             headers.insert("User-Agent", HeaderValue::from_static("Forge"));
         }
-        headers.insert("X-Title", HeaderValue::from_static("forge"));
+        if !headers.contains_key("X-Title") {
+            headers.insert("X-Title", HeaderValue::from_static("forge"));
+        }
         headers.insert(
             "x-app-version",
             HeaderValue::from_str(format!("v{VERSION}").as_str())
                 .unwrap_or(HeaderValue::from_static("v0.1.0-dev")),
         );
-        headers.insert(
-            "HTTP-Referer",
-            HeaderValue::from_static("https://forgecode.dev"),
-        );
+        if !headers.contains_key("HTTP-Referer") {
+            headers.insert(
+                "HTTP-Referer",
+                HeaderValue::from_static("https://forgecode.dev"),
+            );
+        };
         headers.insert(
             reqwest::header::CONNECTION,
             HeaderValue::from_static("keep-alive"),
@@ -505,6 +509,42 @@ mod tests {
         let mut expected = body.to_vec();
         expected.push(b'\n');
         assert_eq!(writes[0].1, Bytes::from(expected));
+    }
+
+    #[test]
+    fn test_headers_preserve_provider_overrides() {
+        use reqwest::header::HeaderValue;
+
+        let file_writer = MockFileWriter::new();
+        let fixture = ForgeHttpInfra::new(create_test_config(None), Arc::new(file_writer));
+
+        let mut headers = HeaderMap::new();
+        headers.insert("user-agent", HeaderValue::from_static("Kilo-Code/5.10.0"));
+        headers.insert("x-title", HeaderValue::from_static("Kilo Code"));
+        headers.insert(
+            "http-referer",
+            HeaderValue::from_static("https://kilocode.ai"),
+        );
+
+        let actual = fixture.headers(Some(headers));
+
+        assert_eq!(
+            actual.get("user-agent"),
+            Some(&HeaderValue::from_static("Kilo-Code/5.10.0"))
+        );
+        assert_eq!(
+            actual.get("x-title"),
+            Some(&HeaderValue::from_static("Kilo Code"))
+        );
+        assert_eq!(
+            actual.get("http-referer"),
+            Some(&HeaderValue::from_static("https://kilocode.ai"))
+        );
+        assert_eq!(
+            actual.get("x-app-version").is_some(),
+            true,
+            "x-app-version should still be added"
+        );
     }
 
     #[test]

--- a/crates/forge_infra/src/http.rs
+++ b/crates/forge_infra/src/http.rs
@@ -540,9 +540,8 @@ mod tests {
             actual.get("http-referer"),
             Some(&HeaderValue::from_static("https://kilocode.ai"))
         );
-        assert_eq!(
+        assert!(
             actual.get("x-app-version").is_some(),
-            true,
             "x-app-version should still be added"
         );
     }

--- a/crates/forge_repo/src/provider/anthropic.rs
+++ b/crates/forge_repo/src/provider/anthropic.rs
@@ -15,7 +15,7 @@ use forge_domain::{ChatRepository, Provider, ProviderId};
 use futures::StreamExt;
 use reqwest::Url;
 use reqwest::header::HeaderMap;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::provider::event::into_chat_completion_message;
 use crate::provider::retry::into_retry;
@@ -84,6 +84,24 @@ impl<H: HttpInfra> Anthropic<H> {
 
         if let Some(custom_headers) = &self.provider.custom_headers {
             for (key, value) in custom_headers {
+                if let Err(error) = reqwest::header::HeaderName::try_from(key.as_str()) {
+                    warn!(
+                        provider = %self.provider.id,
+                        header_name = %key,
+                        error = %error,
+                        "Skipping invalid provider custom header name"
+                    );
+                    continue;
+                }
+                if let Err(error) = reqwest::header::HeaderValue::from_str(value) {
+                    warn!(
+                        provider = %self.provider.id,
+                        header_name = %key,
+                        error = %error,
+                        "Skipping invalid provider custom header value"
+                    );
+                    continue;
+                }
                 headers.push((key.clone(), value.clone()));
             }
         }
@@ -965,6 +983,59 @@ mod tests {
             actual
                 .iter()
                 .any(|(key, value)| key == "X-Custom-Header" && value == "custom-value")
+        );
+    }
+
+    #[test]
+    fn test_get_headers_skips_invalid_provider_custom_headers() {
+        let chat_url = Url::parse("https://api.anthropic.com/v1/messages").unwrap();
+        let model_url = Url::parse("https://api.anthropic.com/v1/models").unwrap();
+
+        let provider = Provider {
+            id: ProviderId::ANTHROPIC,
+            provider_type: forge_domain::ProviderType::Llm,
+            response: Some(forge_app::domain::ProviderResponse::Anthropic),
+            url: chat_url,
+            credential: Some(forge_domain::AuthCredential {
+                id: ProviderId::ANTHROPIC,
+                auth_details: forge_domain::AuthDetails::ApiKey(forge_domain::ApiKey::from(
+                    "sk-test-key".to_string(),
+                )),
+                url_params: std::collections::HashMap::new(),
+            }),
+            auth_methods: vec![forge_domain::AuthMethod::ApiKey],
+            url_params: vec![],
+            models: Some(forge_domain::ModelSource::Url(model_url)),
+            custom_headers: Some(std::collections::HashMap::from([
+                ("Valid-Header".to_string(), "valid-value".to_string()),
+                ("Invalid Header".to_string(), "valid-value".to_string()),
+                ("Another-Invalid".to_string(), "bad\nvalue".to_string()),
+            ])),
+        };
+
+        let fixture = Anthropic::new(
+            Arc::new(MockHttpClient::new()),
+            provider,
+            "2023-06-01".to_string(),
+            false,
+        );
+
+        let actual = fixture.get_headers(Some(&ModelId::new("claude-opus-4-6")));
+
+        assert!(
+            actual
+                .iter()
+                .any(|(key, value)| key == "Valid-Header" && value == "valid-value")
+        );
+        assert!(
+            !actual
+                .iter()
+                .any(|(key, value)| key == "Invalid Header" && value == "valid-value")
+        );
+        assert!(
+            !actual
+                .iter()
+                .any(|(key, value)| key == "Another-Invalid" && value == "bad\nvalue")
         );
     }
 

--- a/crates/forge_repo/src/provider/anthropic.rs
+++ b/crates/forge_repo/src/provider/anthropic.rs
@@ -82,6 +82,12 @@ impl<H: HttpInfra> Anthropic<H> {
             headers.push(("anthropic-beta".to_string(), betas.join(",")));
         }
 
+        if let Some(custom_headers) = &self.provider.custom_headers {
+            for (key, value) in custom_headers {
+                headers.push((key.clone(), value.clone()));
+            }
+        }
+
         headers
     }
 }
@@ -898,6 +904,68 @@ mod tests {
                 model_id
             );
         }
+    }
+
+    #[test]
+    fn test_get_headers_includes_provider_custom_headers() {
+        let chat_url = Url::parse("https://api.anthropic.com/v1/messages").unwrap();
+        let model_url = Url::parse("https://api.anthropic.com/v1/models").unwrap();
+
+        let provider = Provider {
+            id: ProviderId::ANTHROPIC,
+            provider_type: forge_domain::ProviderType::Llm,
+            response: Some(forge_app::domain::ProviderResponse::Anthropic),
+            url: chat_url,
+            credential: Some(forge_domain::AuthCredential {
+                id: ProviderId::ANTHROPIC,
+                auth_details: forge_domain::AuthDetails::ApiKey(forge_domain::ApiKey::from(
+                    "sk-test-key".to_string(),
+                )),
+                url_params: std::collections::HashMap::new(),
+            }),
+            auth_methods: vec![forge_domain::AuthMethod::ApiKey],
+            url_params: vec![],
+            models: Some(forge_domain::ModelSource::Url(model_url)),
+            custom_headers: Some(std::collections::HashMap::from([
+                ("User-Agent".to_string(), "ExampleAgent/1.0".to_string()),
+                (
+                    "HTTP-Referer".to_string(),
+                    "https://example.invalid".to_string(),
+                ),
+                ("X-Title".to_string(), "Example Agent".to_string()),
+                ("X-Custom-Header".to_string(), "custom-value".to_string()),
+            ])),
+        };
+
+        let fixture = Anthropic::new(
+            Arc::new(MockHttpClient::new()),
+            provider,
+            "2023-06-01".to_string(),
+            false,
+        );
+
+        let actual = fixture.get_headers(Some(&ModelId::new("claude-opus-4-6")));
+
+        assert!(
+            actual
+                .iter()
+                .any(|(key, value)| key == "User-Agent" && value == "ExampleAgent/1.0")
+        );
+        assert!(
+            actual
+                .iter()
+                .any(|(key, value)| key == "HTTP-Referer" && value == "https://example.invalid")
+        );
+        assert!(
+            actual
+                .iter()
+                .any(|(key, value)| key == "X-Title" && value == "Example Agent")
+        );
+        assert!(
+            actual
+                .iter()
+                .any(|(key, value)| key == "X-Custom-Header" && value == "custom-value")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve provider header overrides for `User-Agent`, `X-Title`, and `HTTP-Referer`
- forward `provider.custom_headers` on Anthropic requests

## Why
Forge currently applies global HTTP defaults in a way that can override provider-specific headers, and the Anthropic provider path ignores `provider.custom_headers` entirely.

That makes some provider integrations impossible to express cleanly through provider config alone.

## Changes
### `crates/forge_infra/src/http.rs`
- only apply Forge defaults for `User-Agent`, `X-Title`, and `HTTP-Referer` when the provider did not already set them
- keep `x-app-version` and `Connection` defaults unchanged
- add a regression test for preserved provider overrides

### `crates/forge_repo/src/provider/anthropic.rs`
- append `provider.custom_headers` to Anthropic request headers
- add a regression test covering provider-level custom headers on the Anthropic path

## Verification
- `cargo test -q -p forge_repo -p forge_infra`
- `cargo check -q`
- patch also applies cleanly on `upstream/main`

Closes #3125

Co-Authored-By: ForgeCode <noreply@forgecode.dev>
