### PR TITLE
docs(github): add curl install option to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -102,6 +102,7 @@ body:
       options:
         - npx forgecode@latest
         - npm install -g forgecode
+        - curl -fsSL https://forgecode.dev/cli | sh
         - Built from source
         - Other
     validations:


### PR DESCRIPTION
## Summary
Add the `curl` one-liner install method to the bug report template's installation source dropdown so users can accurately report how they installed Forge.

## Context
The bug report template asked users to select how they installed Forge, but was missing the `curl -fsSL https://forgecode.dev/cli | sh` install path. Users who installed via the shell script had no accurate option to choose, which could make it harder to reproduce and triage installation-related bugs.

## Changes
- Added `curl -fsSL https://forgecode.dev/cli | sh` as an option in the installation source dropdown of the GitHub bug report template.

## Testing
Open a new bug report issue on GitHub and verify the installation source dropdown now includes the curl install option alongside the existing options.

## Links
- Template file: `.github/ISSUE_TEMPLATE/bug_report.yml`
