### PR TITLE
fix(mcp): allow Claude Code names in tool validation

### DIFF
--- a/crates/forge_app/src/tool_resolver.rs
+++ b/crates/forge_app/src/tool_resolver.rs
@@ -50,9 +50,16 @@ impl ToolResolver {
 
     pub fn is_allowed(agent: &Agent, tool_name: &ToolName) -> bool {
         let aliases = deprecated_tool_aliases();
-        // Normalize the incoming tool name using aliases
         let normalized_tool_name = aliases.get(tool_name.as_str()).unwrap_or(tool_name);
-        Self::is_allowed_pattern(&Self::build_patterns(agent), normalized_tool_name)
+        let legacy_mcp_tool_name = normalized_tool_name.to_legacy_mcp_name();
+        let patterns = Self::build_patterns(agent);
+
+        Self::is_allowed_pattern(&patterns, normalized_tool_name)
+            || legacy_mcp_tool_name
+                .as_ref()
+                .is_some_and(|legacy_tool_name| {
+                    Self::is_allowed_pattern(&patterns, legacy_tool_name)
+                })
     }
 
     /// Builds glob patterns from the agent's tool patterns, deduplicating
@@ -334,6 +341,36 @@ mod tests {
         ];
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_exact_legacy_mcp_tool_allows_claude_code_name() {
+        let fixture = Agent::new(
+            AgentId::new("test-agent"),
+            ProviderId::ANTHROPIC,
+            ModelId::new("claude-3-5-sonnet-20241022"),
+        )
+        .tools(vec![ToolName::new("mcp_github_tool_create_issue")]);
+
+        assert!(ToolResolver::is_allowed(
+            &fixture,
+            &ToolName::new("mcp__github__create_issue"),
+        ));
+    }
+
+    #[test]
+    fn test_glob_legacy_mcp_tool_allows_claude_code_name() {
+        let fixture = Agent::new(
+            AgentId::new("test-agent"),
+            ProviderId::ANTHROPIC,
+            ModelId::new("claude-3-5-sonnet-20241022"),
+        )
+        .tools(vec![ToolName::new("mcp_github_tool_*")]);
+
+        assert!(ToolResolver::is_allowed(
+            &fixture,
+            &ToolName::new("mcp__github__create_issue"),
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Allow agent tool validation to accept Claude Code formatted MCP tool names when the agent is configured with Forge's legacy MCP tool names or globs.

## Problem

Custom agents can be configured with MCP tools using Forge's internal legacy format, for example `mcp_github_tool_create_issue` or `mcp_github_tool_*`.

After the Claude Code MCP naming compatibility work, incoming tool calls may arrive as `mcp__github__create_issue`. MCP execution lookup already accepts both formats, but agent tool validation still checked only the incoming name directly. That caused valid MCP calls to be rejected as not allowed.

## Fix

When validating a tool call, continue checking the incoming normalized name and also check its legacy MCP form when the incoming name uses the Claude Code `mcp__{server}__{tool}` format.

## Validation

- Added regression test for exact legacy MCP tool allowlists
- Added regression test for legacy MCP glob allowlists
- Ran `cargo test -p forge_app tool_resolver::tests -- --nocapture`
- Ran `cargo clippy -p forge_app --lib --tests -- -D warnings`
