### PR TITLE
fix: replay reasoning content for DeepSeek

### DIFF
--- a/crates/forge_app/src/dto/openai/transformers/mod.rs
+++ b/crates/forge_app/src/dto/openai/transformers/mod.rs
@@ -1,6 +1,6 @@
 mod drop_tool_call;
 mod github_copilot_reasoning;
-mod kimi_k2_reasoning;
+mod reasoning_content;
 mod make_cerebras_compat;
 mod make_openai_compat;
 mod make_xai_compat;

--- a/crates/forge_app/src/dto/openai/transformers/mod.rs
+++ b/crates/forge_app/src/dto/openai/transformers/mod.rs
@@ -1,12 +1,12 @@
 mod drop_tool_call;
 mod github_copilot_reasoning;
-mod reasoning_content;
 mod make_cerebras_compat;
 mod make_openai_compat;
 mod make_xai_compat;
 mod minimax;
 mod normalize_tool_schema;
 mod pipeline;
+mod reasoning_content;
 mod set_cache;
 mod set_reasoning_effort;
 mod strip_thought_signature;

--- a/crates/forge_app/src/dto/openai/transformers/pipeline.rs
+++ b/crates/forge_app/src/dto/openai/transformers/pipeline.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 use super::drop_tool_call::DropToolCalls;
 use super::github_copilot_reasoning::GitHubCopilotReasoning;
-use super::kimi_k2_reasoning::KimiK2Reasoning;
+use super::reasoning_content::ReasoningContent;
 use super::make_cerebras_compat::MakeCerebrasCompat;
 use super::make_openai_compat::MakeOpenAiCompat;
 use super::make_xai_compat::MakeXaiCompat;
@@ -64,8 +64,10 @@ impl Transformer for ProviderPipeline<'_> {
         let github_copilot_reasoning =
             GitHubCopilotReasoning.when(move |_| provider.id == ProviderId::GITHUB_COPILOT);
 
-        let kimi_k2_reasoning = KimiK2Reasoning.when(move |request: &Request| {
-            provider.id == ProviderId::FIREWORKS_AI || when_model("kimi")(request)
+        let reasoning_content = ReasoningContent.when(move |request: &Request| {
+            provider.id == ProviderId::FIREWORKS_AI
+                || is_deepseek_provider(provider)
+                || when_model("kimi")(request)
         });
 
         let cerebras_compat = MakeCerebrasCompat.when(move |_| provider.id == ProviderId::CEREBRAS);
@@ -91,7 +93,7 @@ impl Transformer for ProviderPipeline<'_> {
             .pipe(set_reasoning_effort)
             .pipe(open_ai_compat)
             .pipe(github_copilot_reasoning)
-            .pipe(kimi_k2_reasoning)
+            .pipe(reasoning_content)
             .pipe(cerebras_compat)
             .pipe(xai_compat)
             .pipe(trim_tool_call_ids)
@@ -104,6 +106,12 @@ impl Transformer for ProviderPipeline<'_> {
 /// Checks if provider is a z.ai provider (zai or zai_coding)
 fn is_zai_provider(provider: &Provider<Url>) -> bool {
     provider.id == ProviderId::ZAI || provider.id == ProviderId::ZAI_CODING
+}
+
+/// Checks if provider is DeepSeek, which requires reasoning to be replayed as
+/// a flat reasoning_content field.
+fn is_deepseek_provider(provider: &Provider<Url>) -> bool {
+    provider.id.as_ref() == "deepseek"
 }
 
 /// Checks if the request model is a gemini-3 model (which supports thought
@@ -297,6 +305,22 @@ mod tests {
             credential: make_credential(ProviderId::FIREWORKS_AI, key),
             custom_headers: None,
             models: Some(ModelSource::Hardcoded(vec![])),
+        }
+    }
+
+    fn deepseek(key: &str) -> Provider<Url> {
+        Provider {
+            id: ProviderId::from_str("deepseek").unwrap(),
+            provider_type: Default::default(),
+            response: Some(ProviderResponse::OpenAI),
+            url: Url::parse("https://api.deepseek.com/chat/completions").unwrap(),
+            auth_methods: vec![forge_domain::AuthMethod::ApiKey],
+            url_params: vec![],
+            credential: make_credential(ProviderId::from_str("deepseek").unwrap(), key),
+            custom_headers: None,
+            models: Some(ModelSource::Url(
+                Url::parse("https://api.deepseek.com/models").unwrap(),
+            )),
         }
     }
 
@@ -792,6 +816,38 @@ mod tests {
     #[test]
     fn test_fireworks_provider_converts_reasoning_details_to_reasoning_content() {
         let provider = fireworks_ai("fireworks-ai");
+        let fixture = Request::default().messages(vec![crate::dto::openai::Message {
+            role: crate::dto::openai::Role::Assistant,
+            content: Some(crate::dto::openai::MessageContent::Text("test".to_string())),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+            reasoning_details: Some(vec![crate::dto::openai::ReasoningDetail {
+                r#type: "reasoning.text".to_string(),
+                text: Some("thinking...".to_string()),
+                signature: None,
+                data: None,
+                id: None,
+                format: None,
+                index: None,
+            }]),
+            reasoning_text: None,
+            reasoning_opaque: None,
+            reasoning_content: None,
+            extra_content: None,
+        }]);
+
+        let mut pipeline = ProviderPipeline::new(&provider);
+        let actual = pipeline.transform(fixture);
+
+        let message = actual.messages.unwrap().into_iter().next().unwrap();
+        assert_eq!(message.reasoning_content, Some("thinking...".to_string()));
+        assert!(message.reasoning_details.is_none());
+    }
+
+    #[test]
+    fn test_deepseek_provider_converts_reasoning_details_to_reasoning_content() {
+        let provider = deepseek("deepseek");
         let fixture = Request::default().messages(vec![crate::dto::openai::Message {
             role: crate::dto::openai::Role::Assistant,
             content: Some(crate::dto::openai::MessageContent::Text("test".to_string())),

--- a/crates/forge_app/src/dto/openai/transformers/pipeline.rs
+++ b/crates/forge_app/src/dto/openai/transformers/pipeline.rs
@@ -5,7 +5,6 @@ use url::Url;
 
 use super::drop_tool_call::DropToolCalls;
 use super::github_copilot_reasoning::GitHubCopilotReasoning;
-use super::reasoning_content::ReasoningContent;
 use super::make_cerebras_compat::MakeCerebrasCompat;
 use super::make_openai_compat::MakeOpenAiCompat;
 use super::make_xai_compat::MakeXaiCompat;
@@ -13,6 +12,7 @@ use super::minimax::SetMinimaxParams;
 use super::normalize_tool_schema::{
     EnforceStrictResponseFormatSchema, EnforceStrictToolSchema, NormalizeToolSchema,
 };
+use super::reasoning_content::ReasoningContent;
 use super::set_cache::SetCache;
 use super::set_reasoning_effort::SetReasoningEffort;
 use super::strip_thought_signature::StripThoughtSignature;

--- a/crates/forge_app/src/dto/openai/transformers/reasoning_content.rs
+++ b/crates/forge_app/src/dto/openai/transformers/reasoning_content.rs
@@ -2,18 +2,19 @@ use forge_domain::Transformer;
 
 use crate::dto::openai::Request;
 
-/// Transformer that converts reasoning_details to kimi_k2's reasoning_content
-/// flat format.
+/// Transformer that converts structured reasoning details to the flat
+/// `reasoning_content` format.
 ///
-/// kimi_k2 models expect reasoning to be sent as a flat `reasoning_content`
-/// string field instead of the OpenRouter-style `reasoning_details` array.
+/// Some OpenAI-compatible providers expect replayed reasoning to be sent as a
+/// flat `reasoning_content` string field instead of the OpenRouter-style
+/// `reasoning_details` array.
 ///
 /// This transformer:
-/// 1. Extracts `reasoning.text` type entries → `reasoning_content`
-/// 2. Removes `reasoning_details` array (kimi_k2 doesn't accept it)
-pub struct KimiK2Reasoning;
+/// 1. Extracts `reasoning.text` type entries into `reasoning_content`
+/// 2. Removes `reasoning_details` because target providers do not accept it
+pub struct ReasoningContent;
 
-impl Transformer for KimiK2Reasoning {
+impl Transformer for ReasoningContent {
     type Value = Request;
 
     fn transform(&mut self, mut request: Self::Value) -> Self::Value {
@@ -29,7 +30,7 @@ impl Transformer for KimiK2Reasoning {
                     // Set flat field
                     message.reasoning_content = reasoning_content;
 
-                    // Remove reasoning_details array (kimi_k2 doesn't accept it)
+                    // Remove reasoning_details array because target providers do not accept it
                     message.reasoning_details = None;
                 }
             }
@@ -70,7 +71,7 @@ mod tests {
         }]);
 
         // Execute
-        let actual = KimiK2Reasoning.transform(fixture);
+        let actual = ReasoningContent.transform(fixture);
 
         // Verify transformation
         let messages = actual.messages.unwrap();
@@ -96,7 +97,7 @@ mod tests {
         }]);
 
         // Execute
-        let actual = KimiK2Reasoning.transform(fixture.clone());
+        let actual = ReasoningContent.transform(fixture.clone());
 
         // Verify - no change since there were no reasoning_details
         let messages = actual.messages.unwrap();


### PR DESCRIPTION
## Summary
Fix DeepSeek v4 tool-call follow-ups by replaying structured reasoning as the provider-compatible `reasoning_content` field.

## Context
DeepSeek rejects OpenAI-compatible chat requests that include the OpenRouter-style `reasoning_details` array during assistant-message replay. This can happen after reasoning models perform tool calls, causing follow-up requests to fail with provider validation errors.

This resolves #3142.

## Changes
- Renamed the Kimi-specific reasoning transformer to the provider-agnostic `ReasoningContent` transformer.
- Reused the existing reasoning-content conversion for Fireworks, Kimi models, and DeepSeek instead of adding a separate DeepSeek-only pipeline step.
- Added DeepSeek provider detection in the OpenAI-compatible provider pipeline.
- Added regression coverage confirming DeepSeek requests convert `reasoning_details` into flat `reasoning_content` and remove the unsupported structured field.

### Key Implementation Details
The provider pipeline now applies `ReasoningContent` when the provider is Fireworks AI, DeepSeek, or a Kimi model. The transformer extracts the `reasoning.text` entry from `reasoning_details`, assigns it to `reasoning_content`, and clears `reasoning_details` before the request is sent to providers that do not accept that field.

## Use Cases
- DeepSeek v4 can continue conversations after shell/tool calls from a reasoning response.
- Multi-tool prompts no longer fail when prior assistant reasoning must be replayed to DeepSeek.
- Existing Kimi and Fireworks reasoning replay behavior remains covered by the shared transformer.

## Testing
```bash
cargo build

FORGE__SESSION_PROVIDER_ID=deepseek \
FORGE__SESSION_MODEL_ID=deepseek-v4-pro \
./target/debug/forge -p "whats the time? check it using shell tool"

FORGE__SESSION_PROVIDER_ID=deepseek \
FORGE__SESSION_MODEL_ID=deepseek-v4-pro \
./target/debug/forge -p "Use the shell tool multiple times to answer this. First run date to get the current time. Then run pwd to get the current directory. Then run uname -s to identify the operating system. After all three tool calls, summarize the results."

cargo test -p forge_app test_deepseek_provider_converts_reasoning_details_to_reasoning_content
cargo test -p forge_app test_fireworks_provider_converts_reasoning_details_to_reasoning_content
cargo test -p forge_app test_converts_reasoning_details_to_reasoning_content
cargo check
```

## Links
- Related issue: #3142
