### PR TITLE
fix(cli): allow hyphen values in suggest command prompt

### DIFF
--- a/crates/forge_main/src/cli.rs
+++ b/crates/forge_main/src/cli.rs
@@ -119,6 +119,7 @@ pub enum TopLevelCommand {
     /// Suggest shell commands from natural language.
     Suggest {
         /// Natural language description of the desired command.
+        #[arg(allow_hyphen_values = true)]
         prompt: String,
     },
 
@@ -1695,6 +1696,39 @@ mod tests {
     fn test_prompt_with_double_hyphen() {
         let fixture = Cli::parse_from(["forge", "-p", "--something"]);
         assert_eq!(fixture.prompt, Some("--something".to_string()));
+    }
+
+    #[test]
+    fn test_suggest_with_dash_prefixed_prompt() {
+        let fixture = Cli::parse_from(["forge", "suggest", "--- date"]);
+        let actual = match fixture.subcommands {
+            Some(TopLevelCommand::Suggest { prompt }) => prompt,
+            _ => panic!("Expected suggest subcommand"),
+        };
+        let expected = "--- date".to_string();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_suggest_with_double_dash_prompt() {
+        let fixture = Cli::parse_from(["forge", "suggest", "--date tomorrow"]);
+        let actual = match fixture.subcommands {
+            Some(TopLevelCommand::Suggest { prompt }) => prompt,
+            _ => panic!("Expected suggest subcommand"),
+        };
+        let expected = "--date tomorrow".to_string();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_suggest_with_single_dash_prompt() {
+        let fixture = Cli::parse_from(["forge", "suggest", "-v file.txt"]);
+        let actual = match fixture.subcommands {
+            Some(TopLevelCommand::Suggest { prompt }) => prompt,
+            _ => panic!("Expected suggest subcommand"),
+        };
+        let expected = "-v file.txt".to_string();
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/crates/forge_main/src/model.rs
+++ b/crates/forge_main/src/model.rs
@@ -481,7 +481,7 @@ pub enum AppCommand {
     #[command(alias = "s")]
     Suggest {
         /// Natural language description of the shell command
-        #[arg(trailing_var_arg = true, num_args = 0..)]
+        #[arg(trailing_var_arg = true, num_args = 0.., allow_hyphen_values = true)]
         description: Vec<String>,
     },
 
@@ -1622,5 +1622,56 @@ mod tests {
     fn test_rename_command_name() {
         let cmd = AppCommand::Rename { name: vec!["test".to_string()] };
         assert_eq!(cmd.name(), "rename");
+    }
+
+    #[test]
+    fn test_parse_suggest_with_dash_prefixed_tokens() {
+        // Setup
+        let cmd_manager = ForgeCommandManager::default();
+
+        // Execute
+        let result = cmd_manager.parse(":suggest --- date").unwrap();
+
+        // Verify
+        assert_eq!(
+            result,
+            AppCommand::Suggest {
+                description: vec!["---".to_string(), "date".to_string()]
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_suggest_with_double_dash_flags() {
+        // Setup
+        let cmd_manager = ForgeCommandManager::default();
+
+        // Execute
+        let result = cmd_manager.parse(":suggest --date tomorrow").unwrap();
+
+        // Verify
+        assert_eq!(
+            result,
+            AppCommand::Suggest {
+                description: vec!["--date".to_string(), "tomorrow".to_string()]
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_suggest_with_single_dash() {
+        // Setup
+        let cmd_manager = ForgeCommandManager::default();
+
+        // Execute
+        let result = cmd_manager.parse(":suggest -v file.txt").unwrap();
+
+        // Verify
+        assert_eq!(
+            result,
+            AppCommand::Suggest {
+                description: vec!["-v".to_string(), "file.txt".to_string()]
+            }
+        );
     }
 }

--- a/crates/forge_main/src/model.rs
+++ b/crates/forge_main/src/model.rs
@@ -1635,9 +1635,7 @@ mod tests {
         // Verify
         assert_eq!(
             result,
-            AppCommand::Suggest {
-                description: vec!["---".to_string(), "date".to_string()]
-            }
+            AppCommand::Suggest { description: vec!["---".to_string(), "date".to_string()] }
         );
     }
 
@@ -1669,9 +1667,7 @@ mod tests {
         // Verify
         assert_eq!(
             result,
-            AppCommand::Suggest {
-                description: vec!["-v".to_string(), "file.txt".to_string()]
-            }
+            AppCommand::Suggest { description: vec!["-v".to_string(), "file.txt".to_string()] }
         );
     }
 }


### PR DESCRIPTION
fixes: #3141 