### PR TITLE
fix: default reasoning_content to empty string for DeepSeek

### DIFF
--- a/crates/forge_app/src/dto/openai/transformers/default_reasoning_content.rs
+++ b/crates/forge_app/src/dto/openai/transformers/default_reasoning_content.rs
@@ -1,0 +1,99 @@
+use forge_domain::Transformer;
+
+use crate::dto::openai::Request;
+
+/// Transformer that ensures every message has a `reasoning_content` field set.
+///
+/// DeepSeek requires the `reasoning_content` field to be present on assistant
+/// messages even when there is no reasoning text. When the field is `None` this
+/// transformer falls back to an empty string.
+pub struct DefaultReasoningContent;
+
+impl Transformer for DefaultReasoningContent {
+    type Value = Request;
+
+    fn transform(&mut self, mut request: Self::Value) -> Self::Value {
+        if let Some(ref mut messages) = request.messages {
+            for message in messages.iter_mut() {
+                if message.reasoning_content.is_none() {
+                    message.reasoning_content = Some(String::new());
+                }
+            }
+        }
+        request
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+    use crate::dto::openai::{Message, MessageContent, Request, Role};
+
+    #[test]
+    fn test_sets_empty_string_when_reasoning_content_is_none() {
+        let fixture = Request::default().messages(vec![Message {
+            role: Role::Assistant,
+            content: Some(MessageContent::Text("test".to_string())),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+            reasoning_details: None,
+            reasoning_text: None,
+            reasoning_opaque: None,
+            reasoning_content: None,
+            extra_content: None,
+        }]);
+
+        let actual = DefaultReasoningContent.transform(fixture);
+
+        let messages = actual.messages.unwrap();
+        let msg = messages.first().unwrap();
+        assert_eq!(msg.reasoning_content, Some(String::new()));
+    }
+
+    #[test]
+    fn test_preserves_existing_reasoning_content() {
+        let fixture = Request::default().messages(vec![Message {
+            role: Role::Assistant,
+            content: Some(MessageContent::Text("test".to_string())),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+            reasoning_details: None,
+            reasoning_text: None,
+            reasoning_opaque: None,
+            reasoning_content: Some("thinking...".to_string()),
+            extra_content: None,
+        }]);
+
+        let actual = DefaultReasoningContent.transform(fixture);
+
+        let messages = actual.messages.unwrap();
+        let msg = messages.first().unwrap();
+        assert_eq!(msg.reasoning_content, Some("thinking...".to_string()));
+    }
+
+    #[test]
+    fn test_preserves_preserves_empty_string_when_already_set() {
+        let fixture = Request::default().messages(vec![Message {
+            role: Role::Assistant,
+            content: Some(MessageContent::Text("test".to_string())),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+            reasoning_details: None,
+            reasoning_text: None,
+            reasoning_opaque: None,
+            reasoning_content: Some(String::new()),
+            extra_content: None,
+        }]);
+
+        let actual = DefaultReasoningContent.transform(fixture);
+
+        let messages = actual.messages.unwrap();
+        let msg = messages.first().unwrap();
+        assert_eq!(msg.reasoning_content, Some(String::new()));
+    }
+}

--- a/crates/forge_app/src/dto/openai/transformers/mod.rs
+++ b/crates/forge_app/src/dto/openai/transformers/mod.rs
@@ -1,3 +1,4 @@
+mod default_reasoning_content;
 mod drop_tool_call;
 mod github_copilot_reasoning;
 mod make_cerebras_compat;

--- a/crates/forge_app/src/dto/openai/transformers/pipeline.rs
+++ b/crates/forge_app/src/dto/openai/transformers/pipeline.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use forge_domain::{DefaultTransformation, Provider, ProviderId, Transformer};
 use url::Url;
 
+use super::default_reasoning_content::DefaultReasoningContent;
 use super::drop_tool_call::DropToolCalls;
 use super::github_copilot_reasoning::GitHubCopilotReasoning;
 use super::make_cerebras_compat::MakeCerebrasCompat;
@@ -70,6 +71,9 @@ impl Transformer for ProviderPipeline<'_> {
                 || when_model("kimi")(request)
         });
 
+        let default_reasoning_content =
+            DefaultReasoningContent.when(move |_| is_deepseek_provider(provider));
+
         let cerebras_compat = MakeCerebrasCompat.when(move |_| provider.id == ProviderId::CEREBRAS);
 
         let xai_compat = MakeXaiCompat.when(move |_| provider.id == ProviderId::XAI);
@@ -94,6 +98,7 @@ impl Transformer for ProviderPipeline<'_> {
             .pipe(open_ai_compat)
             .pipe(github_copilot_reasoning)
             .pipe(reasoning_content)
+            .pipe(default_reasoning_content)
             .pipe(cerebras_compat)
             .pipe(xai_compat)
             .pipe(trim_tool_call_ids)
@@ -875,6 +880,29 @@ mod tests {
         let message = actual.messages.unwrap().into_iter().next().unwrap();
         assert_eq!(message.reasoning_content, Some("thinking...".to_string()));
         assert!(message.reasoning_details.is_none());
+    }
+
+    #[test]
+    fn test_deepseek_provider_falls_back_to_empty_reasoning_content_when_none() {
+        let provider = deepseek("deepseek");
+        let fixture = Request::default().messages(vec![crate::dto::openai::Message {
+            role: crate::dto::openai::Role::Assistant,
+            content: Some(crate::dto::openai::MessageContent::Text("test".to_string())),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+            reasoning_details: None,
+            reasoning_text: None,
+            reasoning_opaque: None,
+            reasoning_content: None,
+            extra_content: None,
+        }]);
+
+        let mut pipeline = ProviderPipeline::new(&provider);
+        let actual = pipeline.transform(fixture);
+
+        let message = actual.messages.unwrap().into_iter().next().unwrap();
+        assert_eq!(message.reasoning_content, Some(String::new()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Add a `DefaultReasoningContent` transformer that ensures the `reasoning_content` field is always present on messages sent to the DeepSeek provider, falling back to an empty string when no reasoning text exists.

## Context
DeepSeek requires `reasoning_content` to be present on assistant messages even when there is no reasoning text. Without this field, DeepSeek rejects the request. The existing `ReasoningContent` transformer extracts reasoning text from `reasoning_details` but leaves `reasoning_content` as `None` when there are no reasoning details. This new transformer fills in the gap.

## Changes
- Added a new `DefaultReasoningContent` transformer that sets `reasoning_content` to an empty string when it is `None`
- Wired it into the provider pipeline gated exclusively to the DeepSeek provider
- Added unit tests for the transformer itself and the DeepSeek pipeline integration

### Key Implementation Details
The new transformer runs **after** `ReasoningContent` in the pipeline, so it only fills in the fallback when `ReasoningContent` (or any earlier transformer) left the field as `None`. It is gated by `is_deepseek_provider()` and does not affect any other provider.

Pipeline ordering:
```
ReasoningContent → DefaultReasoningContent → ...
```

## Testing
```bash
# Run the new transformer unit tests
cargo test --package forge_app -- dto::openai::transformers::default_reasoning_content --nocapture

# Run the DeepSeek pipeline integration test
cargo test --package forge_app -- dto::openai::transformers::pipeline::tests::test_deepseek_provider_falls_back_to_empty_reasoning_content_when_none --nocapture

# Run all transformer tests
cargo test --package forge_app -- dto::openai::transformers --nocapture
```
