### PR TITLE
fix: propagate reasoning_effort to DeepSeek API

### DIFF
--- a/crates/forge_app/src/dto/openai/transformers/pipeline.rs
+++ b/crates/forge_app/src/dto/openai/transformers/pipeline.rs
@@ -59,7 +59,9 @@ impl Transformer for ProviderPipeline<'_> {
         let open_ai_compat = MakeOpenAiCompat.when(move |_| !supports_open_router_params(provider));
 
         let set_reasoning_effort = SetReasoningEffort.when(move |_| {
-            provider.id == ProviderId::REQUESTY || provider.id == ProviderId::GITHUB_COPILOT
+            provider.id == ProviderId::REQUESTY
+                || provider.id == ProviderId::GITHUB_COPILOT
+                || is_deepseek_provider(provider)
         });
 
         let github_copilot_reasoning =
@@ -903,6 +905,40 @@ mod tests {
 
         let message = actual.messages.unwrap().into_iter().next().unwrap();
         assert_eq!(message.reasoning_content, Some(String::new()));
+    }
+
+    #[test]
+    fn test_deepseek_provider_applies_reasoning_effort() {
+        let provider = deepseek("deepseek");
+        let fixture = Request::default().reasoning(forge_domain::ReasoningConfig {
+            enabled: Some(true),
+            effort: Some(forge_domain::Effort::High),
+            max_tokens: None,
+            exclude: None,
+        });
+
+        let mut pipeline = ProviderPipeline::new(&provider);
+        let actual = pipeline.transform(fixture);
+
+        assert_eq!(actual.reasoning_effort, Some("high".to_string()));
+        assert_eq!(actual.reasoning, None);
+    }
+
+    #[test]
+    fn test_deepseek_provider_sets_reasoning_effort_none_when_disabled() {
+        let provider = deepseek("deepseek");
+        let fixture = Request::default().reasoning(forge_domain::ReasoningConfig {
+            enabled: Some(false),
+            effort: Some(forge_domain::Effort::High),
+            max_tokens: None,
+            exclude: None,
+        });
+
+        let mut pipeline = ProviderPipeline::new(&provider);
+        let actual = pipeline.transform(fixture);
+
+        assert_eq!(actual.reasoning_effort, Some("none".to_string()));
+        assert_eq!(actual.reasoning, None);
     }
 
     #[test]

--- a/crates/forge_app/src/dto/openai/transformers/set_reasoning_effort.rs
+++ b/crates/forge_app/src/dto/openai/transformers/set_reasoning_effort.rs
@@ -5,8 +5,9 @@ use crate::dto::openai::Request;
 /// Transformer that converts standard ReasoningConfig to reasoning_effort
 /// format
 ///
-/// OpenAI-compatible APIs expect `reasoning_effort` parameter instead of the
-/// internal `reasoning` config object.
+/// OpenAI-compatible APIs (Requesty, GitHub Copilot, DeepSeek) expect
+/// `reasoning_effort` parameter instead of the internal `reasoning` config
+/// object.
 ///
 /// # Transformation Rules
 ///


### PR DESCRIPTION
## Problem

DeepSeek V4-Pro and V4-Flash support the `reasoning_effort` parameter (`high`/`max`) as documented at https://api-docs.deepseek.com/zh-cn/guides/thinking_mode. For complex agent scenarios, DeepSeek recommends using thinking mode with `max` effort.

Currently, the `SetReasoningEffort` transformer only activates for Requesty and GitHub Copilot. DeepSeek is excluded, so the user's `[reasoning]` configuration (effort level, enabled flag) is silently dropped by `MakeOpenAiCompat` and never reaches the API.

## Solution

Add `is_deepseek_provider(provider)` to the activation guard of `SetReasoningEffort` in the provider pipeline, so that `reasoning.effort` is properly converted to `reasoning_effort` for DeepSeek.

## Changes

- **`pipeline.rs`**: Enable `SetReasoningEffort` for DeepSeek providers
- **`set_reasoning_effort.rs`**: Update doc comment to list DeepSeek
- **`pipeline.rs` tests**: Add two tests verifying:
  - `reasoning.effort = High` → `reasoning_effort = "high"`
  - `reasoning.enabled = false` → `reasoning_effort = "none"`

## Verification

- The `SetReasoningEffort` transformer runs **before** `MakeOpenAiCompat` in the pipeline (line 99-100), so `reasoning_effort` survives the OpenAI compat cleanup
- Existing `ReasoningContent` and `DefaultReasoningContent` tests for DeepSeek continue to pass
- New pipeline tests verify the full integration