### PR TITLE
chore(cli): add forge logs command

### DIFF
--- a/crates/forge_main/src/cli.rs
+++ b/crates/forge_main/src/cli.rs
@@ -149,6 +149,9 @@ pub enum TopLevelCommand {
 
     /// Run diagnostics on shell environment (alias for `zsh doctor`).
     Doctor,
+
+    /// Stream forge log output (defaults to the most recent log file).
+    Logs(LogsArgs),
 }
 
 /// Command group for custom command management.
@@ -817,6 +820,27 @@ pub struct UpdateArgs {
     /// Skip the confirmation prompt when applying updates.
     #[arg(long, default_value_t = false)]
     pub no_confirm: bool,
+}
+
+/// Arguments for the `forge logs` command.
+#[derive(Parser, Debug, Clone)]
+pub struct LogsArgs {
+    /// Number of lines to show from the end of the log file.
+    #[arg(long, short = 'n', default_value_t = 20)]
+    pub lines: usize,
+
+    /// Do not follow the log output; exit after printing the last lines.
+    #[arg(long)]
+    pub no_follow: bool,
+
+    /// List all available log files instead of tailing one.
+    #[arg(long, short = 'l')]
+    pub list: bool,
+
+    /// Path to a specific log file to tail. Defaults to the most recent log
+    /// file in the forge logs directory.
+    #[arg(long, short = 'f')]
+    pub file: Option<PathBuf>,
 }
 
 #[cfg(test)]

--- a/crates/forge_main/src/lib.rs
+++ b/crates/forge_main/src/lib.rs
@@ -8,6 +8,7 @@ mod error;
 mod highlighter;
 mod info;
 mod input;
+mod logs;
 mod model;
 mod oauth_callback;
 mod porcelain;

--- a/crates/forge_main/src/logs.rs
+++ b/crates/forge_main/src/logs.rs
@@ -35,12 +35,11 @@ async fn collect_files(log_dir: &Path) -> Result<Vec<(SystemTime, PathBuf)>> {
     let mut files = Vec::new();
     while let Some(entry) = entries.next_entry().await? {
         // Single metadata call per entry covers both is_file() and modified().
-        if let Ok(meta) = entry.metadata().await {
-            if meta.is_file() {
+        if let Ok(meta) = entry.metadata().await
+            && meta.is_file() {
                 let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
                 files.push((mtime, entry.path()));
             }
-        }
     }
     Ok(files)
 }

--- a/crates/forge_main/src/logs.rs
+++ b/crates/forge_main/src/logs.rs
@@ -1,0 +1,105 @@
+//! `forge logs` — stream or list forge log files.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use crate::cli::LogsArgs;
+
+/// Entry point called from the CLI handler.
+pub async fn run(args: LogsArgs, log_dir: PathBuf) -> Result<()> {
+    if args.list {
+        list(&log_dir).await
+    } else {
+        let file = match args.file {
+            Some(path) => path,
+            None => latest(&log_dir).await?,
+        };
+        tail(&file, args.lines, args.no_follow).await
+    }
+}
+
+/// Returns the path of the most recently modified file inside `log_dir`.
+async fn latest(log_dir: &Path) -> Result<PathBuf> {
+    let mut entries = tokio::fs::read_dir(log_dir).await.with_context(|| {
+        format!(
+            "Log directory not found: {}. Run forge at least once to generate logs.",
+            log_dir.display()
+        )
+    })?;
+
+    let mut files: Vec<(std::time::SystemTime, PathBuf)> = Vec::new();
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        if tokio::fs::metadata(&path).await.map(|m| m.is_file()).unwrap_or(false) {
+            let mtime = entry
+                .metadata()
+                .await
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+            files.push((mtime, path));
+        }
+    }
+
+    files.sort_unstable_by_key(|(mtime, _)| *mtime);
+    files
+        .into_iter()
+        .next_back()
+        .map(|(_, p)| p)
+        .ok_or_else(|| anyhow::anyhow!("No log files found in {}", log_dir.display()))
+}
+
+/// Lists all log files in `log_dir`, newest first, one path per line on stdout.
+async fn list(log_dir: &Path) -> Result<()> {
+    let mut entries = tokio::fs::read_dir(log_dir).await.with_context(|| {
+        format!(
+            "Log directory not found: {}. Run forge at least once to generate logs.",
+            log_dir.display()
+        )
+    })?;
+
+    let mut files: Vec<(std::time::SystemTime, PathBuf)> = Vec::new();
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        if tokio::fs::metadata(&path).await.map(|m| m.is_file()).unwrap_or(false) {
+            let mtime = entry
+                .metadata()
+                .await
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+            files.push((mtime, path));
+        }
+    }
+
+    files.sort_unstable_by_key(|(mtime, _)| *mtime);
+    for (_, path) in files.iter().rev() {
+        println!("{}", path.display());
+    }
+
+    Ok(())
+}
+
+/// Spawns `tail` asynchronously, inheriting stdout/stderr.
+async fn tail(log_file: &Path, lines: usize, no_follow: bool) -> Result<()> {
+    let mut cmd = tokio::process::Command::new("tail");
+    cmd.arg(format!("-n{lines}"));
+    if !no_follow {
+        cmd.arg("-f");
+    }
+    cmd.arg(log_file);
+
+    let status = cmd.status().await.with_context(|| {
+        format!(
+            "Failed to run tail on {}. Is `tail` installed?",
+            log_file.display()
+        )
+    })?;
+
+    if !status.success() {
+        anyhow::bail!("tail exited with status {}", status.code().unwrap_or(-1));
+    }
+
+    Ok(())
+}

--- a/crates/forge_main/src/logs.rs
+++ b/crates/forge_main/src/logs.rs
@@ -36,10 +36,11 @@ async fn collect_files(log_dir: &Path) -> Result<Vec<(SystemTime, PathBuf)>> {
     while let Some(entry) = entries.next_entry().await? {
         // Single metadata call per entry covers both is_file() and modified().
         if let Ok(meta) = entry.metadata().await
-            && meta.is_file() {
-                let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
-                files.push((mtime, entry.path()));
-            }
+            && meta.is_file()
+        {
+            let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+            files.push((mtime, entry.path()));
+        }
     }
     Ok(files)
 }

--- a/crates/forge_main/src/logs.rs
+++ b/crates/forge_main/src/logs.rs
@@ -1,6 +1,7 @@
 //! `forge logs` — stream or list forge log files.
 
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use anyhow::{Context, Result};
 
@@ -19,8 +20,11 @@ pub async fn run(args: LogsArgs, log_dir: PathBuf) -> Result<()> {
     }
 }
 
-/// Returns the path of the most recently modified file inside `log_dir`.
-async fn latest(log_dir: &Path) -> Result<PathBuf> {
+/// Collects every regular file in `log_dir` as `(mtime, path)` pairs.
+///
+/// Uses a single `entry.metadata()` call per entry — one syscall covers both
+/// the `is_file()` check and the `modified()` timestamp.
+async fn collect_files(log_dir: &Path) -> Result<Vec<(SystemTime, PathBuf)>> {
     let mut entries = tokio::fs::read_dir(log_dir).await.with_context(|| {
         format!(
             "Log directory not found: {}. Run forge at least once to generate logs.",
@@ -28,56 +32,38 @@ async fn latest(log_dir: &Path) -> Result<PathBuf> {
         )
     })?;
 
-    let mut files: Vec<(std::time::SystemTime, PathBuf)> = Vec::new();
+    let mut files = Vec::new();
     while let Some(entry) = entries.next_entry().await? {
-        let path = entry.path();
-        if tokio::fs::metadata(&path).await.map(|m| m.is_file()).unwrap_or(false) {
-            let mtime = entry
-                .metadata()
-                .await
-                .ok()
-                .and_then(|m| m.modified().ok())
-                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-            files.push((mtime, path));
+        // Single metadata call per entry covers both is_file() and modified().
+        if let Ok(meta) = entry.metadata().await {
+            if meta.is_file() {
+                let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+                files.push((mtime, entry.path()));
+            }
         }
     }
+    Ok(files)
+}
 
-    files.sort_unstable_by_key(|(mtime, _)| *mtime);
+/// Returns the path of the most recently modified file inside `log_dir`.
+///
+/// Uses a linear O(n) scan rather than sorting — we only need the maximum.
+async fn latest(log_dir: &Path) -> Result<PathBuf> {
+    let files = collect_files(log_dir).await?;
     files
         .into_iter()
-        .next_back()
+        .max_by_key(|(mtime, _)| *mtime)
         .map(|(_, p)| p)
         .ok_or_else(|| anyhow::anyhow!("No log files found in {}", log_dir.display()))
 }
 
 /// Lists all log files in `log_dir`, newest first, one path per line on stdout.
 async fn list(log_dir: &Path) -> Result<()> {
-    let mut entries = tokio::fs::read_dir(log_dir).await.with_context(|| {
-        format!(
-            "Log directory not found: {}. Run forge at least once to generate logs.",
-            log_dir.display()
-        )
-    })?;
-
-    let mut files: Vec<(std::time::SystemTime, PathBuf)> = Vec::new();
-    while let Some(entry) = entries.next_entry().await? {
-        let path = entry.path();
-        if tokio::fs::metadata(&path).await.map(|m| m.is_file()).unwrap_or(false) {
-            let mtime = entry
-                .metadata()
-                .await
-                .ok()
-                .and_then(|m| m.modified().ok())
-                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-            files.push((mtime, path));
-        }
-    }
-
+    let mut files = collect_files(log_dir).await?;
     files.sort_unstable_by_key(|(mtime, _)| *mtime);
     for (_, path) in files.iter().rev() {
         println!("{}", path.display());
     }
-
     Ok(())
 }
 

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -737,6 +737,11 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                 self.on_zsh_doctor().await?;
                 return Ok(());
             }
+            TopLevelCommand::Logs(args) => {
+                let log_dir = self.api.environment().log_path();
+                crate::logs::run(args, log_dir).await?;
+                return Ok(());
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary
Add a `forge logs` command that lets users stream, tail, or list forge log files directly from the CLI — no more hunting through the filesystem to find log output.

## Context
Debugging forge issues currently requires manually locating the log directory and running `tail` against the right file. This adds friction, especially when there are multiple log files and you just want to see what's happening right now. The new `logs` command automates this with sane defaults.

## Changes
- Added `forge logs` top-level CLI command with `LogsArgs` parser
- Implemented `crates/forge_main/src/logs.rs` with three operations: tail (default), list, and explicit file selection
- Wired the command into the UI dispatch loop via `TopLevelCommand::Logs`

### Key Implementation Details
- **Default behaviour**: tails the most recently modified log file with `-f` (follow) enabled, showing the last 20 lines — mirrors the typical `tail -f` workflow
- **`--no-follow` / `-n`**: print the last N lines and exit, useful for scripting or quick inspection
- **`--list` / `-l`**: prints all log files newest-first so users can identify which file to target
- **`--file` / `-f`**: explicit path override when a specific session's log is needed
- **Performance**: `collect_files` performs a single `metadata()` syscall per directory entry covering both the `is_file()` check and the `modified()` timestamp; finding the latest file is an O(n) linear scan rather than a sort, avoiding unnecessary allocations

## Use Cases
```bash
# Follow the latest log in real time (default)
forge logs

# Print the last 50 lines and exit
forge logs -n 50 --no-follow

# List all available log files
forge logs --list

# Tail a specific session's log
forge logs --file ~/.local/share/forge/logs/session-abc123.log
```

## Testing
```bash
# Build and run
cargo build
forge logs --list          # should print log file paths, newest first
forge logs --no-follow     # should print last 20 lines and exit
forge logs -n 5 --no-follow  # should print last 5 lines
```
