### PR TITLE
chore: remove file sync log spam and unused logs command

### DIFF
--- a/crates/forge_services/src/sync.rs
+++ b/crates/forge_services/src/sync.rs
@@ -281,38 +281,34 @@ impl<F: 'static + WorkspaceIndexRepository + FileReaderInfra, D: FileDiscovery +
         let infra = self.infra.clone();
         let batch_size = self.batch_size;
 
-        futures::stream::iter(paths).chunks(batch_size).then(move |batch| {
-            let user_id = user_id.clone();
-            let workspace_id = workspace_id.clone();
-            let token = token.clone();
-            let infra = infra.clone();
-            async move {
-                let mut files = Vec::with_capacity(batch.len());
-                for file_path in &batch {
-                    let content = infra
-                        .read_utf8(file_path)
-                        .await
-                        .with_context(|| {
+        futures::stream::iter(paths)
+            .chunks(batch_size)
+            .then(move |batch| {
+                let user_id = user_id.clone();
+                let workspace_id = workspace_id.clone();
+                let token = token.clone();
+                let infra = infra.clone();
+                async move {
+                    let mut files = Vec::with_capacity(batch.len());
+                    for file_path in &batch {
+                        let content = infra.read_utf8(file_path).await.with_context(|| {
                             format!("Failed to read file '{}' for upload", file_path.display())
                         })?;
-                    files.push(forge_domain::FileRead::new(
-                        file_path.to_string_lossy().into_owned(),
-                        content,
-                    ));
+                        files.push(forge_domain::FileRead::new(
+                            file_path.to_string_lossy().into_owned(),
+                            content,
+                        ));
+                    }
+                    let count = files.len();
+                    let upload =
+                        forge_domain::CodeBase::new(user_id.clone(), workspace_id.clone(), files);
+                    infra
+                        .upload_files(&upload, &token)
+                        .await
+                        .context("Failed to upload files")?;
+                    Ok::<_, anyhow::Error>(count)
                 }
-                let count = files.len();
-                let upload = forge_domain::CodeBase::new(
-                    user_id.clone(),
-                    workspace_id.clone(),
-                    files,
-                );
-                infra
-                    .upload_files(&upload, &token)
-                    .await
-                    .context("Failed to upload files")?;
-                Ok::<_, anyhow::Error>(count)
-            }
-        })
+            })
     }
 
     /// Discovers workspace files and streams their hashes without retaining

--- a/crates/forge_services/src/sync.rs
+++ b/crates/forge_services/src/sync.rs
@@ -289,7 +289,6 @@ impl<F: 'static + WorkspaceIndexRepository + FileReaderInfra, D: FileDiscovery +
             async move {
                 let mut files = Vec::with_capacity(batch.len());
                 for file_path in &batch {
-                    info!(workspace_id = %workspace_id, path = %file_path.display(), "File sync started");
                     let content = infra
                         .read_utf8(file_path)
                         .await
@@ -311,9 +310,6 @@ impl<F: 'static + WorkspaceIndexRepository + FileReaderInfra, D: FileDiscovery +
                     .upload_files(&upload, &token)
                     .await
                     .context("Failed to upload files")?;
-                for file_path in &batch {
-                    info!(workspace_id = %workspace_id, path = %file_path.display(), "File sync completed");
-                }
                 Ok::<_, anyhow::Error>(count)
             }
         })


### PR DESCRIPTION
## Summary
Remove noisy log spam from the file sync pipeline and drop the unused `forge logs` CLI command.

## Context
Two sources of high-frequency log noise were identified:

1. **File sync logs**: Every file processed during workspace indexing emitted two `INFO` log lines — "File sync started" and "File sync completed". For a workspace with hundreds or thousands of files, this produced thousands of redundant log entries per sync cycle, drowning out meaningful log output.

2. **`forge logs` command**: The `forge logs` CLI subcommand and its supporting module (`logs.rs`, `LogsArgs`) were added to stream/tail forge log files. The command has since become unnecessary and was removing dead weight from the binary and CLI surface.

## Changes
- Removed `"File sync started"` and `"File sync completed"` `info!` log calls from the batch file sync loop in `crates/forge_services/src/sync.rs`
- Deleted the `forge logs` CLI subcommand (`TopLevelCommand::Logs`) and its `LogsArgs` struct from `crates/forge_main/src/cli.rs`
- Deleted `crates/forge_main/src/logs.rs` (the entire log-tailing module)
- Removed the `mod logs` declaration and the `TopLevelCommand::Logs` dispatch arm from `crates/forge_main/src/lib.rs` and `ui.rs`

## Testing
```bash
# Verify the project compiles cleanly
cargo check

# Confirm the logs subcommand is gone
cargo run -- --help   # should not list a "logs" subcommand

# Run existing tests
cargo insta test --accept
```
