### PR TITLE
fix(shell-plugin): use forge exec for config list and remove logs command

### DIFF
--- a/shell-plugin/lib/actions/config.zsh
+++ b/shell-plugin/lib/actions/config.zsh
@@ -447,7 +447,7 @@ function _forge_action_config_reasoning_effort() {
 # Action handler: Show config list
 function _forge_action_config() {
     echo
-    $_FORGE_BIN config list
+    _forge_exec config list
 }
 
 # Action handler: Open the global forge config file in an editor


### PR DESCRIPTION
## Summary
Fix the shell plugin's config action to use `_forge_exec` instead of invoking the binary directly, and remove the now-unused `forge logs` CLI command.

## Context
The shell plugin's `_forge_action_config` function was calling `$_FORGE_BIN config list` directly, bypassing the `_forge_exec` wrapper that ensures the correct environment and PATH are set up before running forge commands. This could cause the config list to run in an inconsistent environment.

Additionally, the `forge logs` command (which shelled out to `tail`) was found to be unused/unnecessary and has been cleaned up to reduce CLI surface area and dead code.

## Changes
- **shell-plugin**: Replace `$_FORGE_BIN config list` with `_forge_exec config list` in `_forge_action_config` so the exec wrapper is consistently used
- **Remove `forge logs` command**: Delete `cli.rs` `Logs(LogsArgs)` variant, `LogsArgs` struct, the entire `logs.rs` module, and its dispatch branch in `ui.rs`

## Testing
```bash
# Verify config list works through the shell plugin
forge config

# Verify `forge logs` is no longer a recognised command
forge logs  # should print an error / usage hint

# Run crate tests
cargo insta test --accept -p forge_main
```

## Links
- No related issues
