### PR TITLE
fix: retry Codex 503 responses

### DIFF
--- a/crates/forge_repo/src/provider/openai_responses/repository.rs
+++ b/crates/forge_repo/src/provider/openai_responses/repository.rs
@@ -464,10 +464,9 @@ mod tests {
         Content, Context as ChatContext, ContextMessage, FinishReason, ModelId, Provider,
         ProviderId, ProviderResponse,
     };
+    use pretty_assertions::assert_eq;
     use tokio_stream::StreamExt;
     use url::Url;
-
-    use pretty_assertions::assert_eq;
 
     use super::*;
     use crate::provider::mock_server::MockServer;

--- a/crates/forge_repo/src/provider/openai_responses/repository.rs
+++ b/crates/forge_repo/src/provider/openai_responses/repository.rs
@@ -10,6 +10,7 @@ use forge_app::{EnvironmentInfra, HttpInfra};
 use forge_domain::{BoxStream, ChatRepository, Provider};
 use forge_infra::sanitize_headers;
 use futures::StreamExt;
+use reqwest::StatusCode;
 use reqwest::header::AUTHORIZATION;
 use tracing::info;
 use url::Url;
@@ -278,7 +279,7 @@ impl<T: HttpInfra> OpenAIResponsesProvider<T> {
                 .text()
                 .await
                 .unwrap_or_else(|_| "Unable to read response body".to_string());
-            return Err(anyhow::anyhow!(error_body))
+            return Err(status_code_error(status, error_body))
                 .with_context(|| format_http_context(Some(status), "POST", &self.responses_url));
         }
 
@@ -324,6 +325,13 @@ impl<T: HttpInfra> OpenAIResponsesProvider<T> {
         let stream: BoxStream<super::response::StreamItem, anyhow::Error> = Box::pin(event_stream);
         stream.into_domain()
     }
+}
+
+fn status_code_error(status: StatusCode, body: String) -> anyhow::Error {
+    anyhow::Error::from(forge_app::dto::openai::Error::InvalidStatusCode(
+        status.as_u16(),
+    ))
+    .context(body)
 }
 
 fn into_sse_parse_error<E>(error: eventsource_stream::EventStreamError<E>) -> anyhow::Error
@@ -459,8 +467,11 @@ mod tests {
     use tokio_stream::StreamExt;
     use url::Url;
 
+    use pretty_assertions::assert_eq;
+
     use super::*;
     use crate::provider::mock_server::MockServer;
+    use crate::provider::retry;
 
     fn is_retryable(error: &anyhow::Error) -> bool {
         error
@@ -599,6 +610,26 @@ mod tests {
                 "output_tokens_details": {"reasoning_tokens": 0}
             }
         })
+    }
+
+    #[test]
+    fn test_status_code_error_preserves_retryable_status_code() {
+        let fixture = StatusCode::SERVICE_UNAVAILABLE;
+
+        let actual = status_code_error(fixture, "Connection refused".to_string());
+
+        let expected = Some(503);
+        assert_eq!(retry::get_api_status_code(&actual), expected);
+    }
+
+    #[test]
+    fn test_status_code_error_preserves_body_context() {
+        let fixture = "Connection refused".to_string();
+
+        let actual = status_code_error(StatusCode::SERVICE_UNAVAILABLE, fixture.clone());
+
+        let expected = true;
+        assert_eq!(actual.to_string().contains(&fixture), expected);
     }
 
     #[test]

--- a/crates/forge_repo/src/provider/retry.rs
+++ b/crates/forge_repo/src/provider/retry.rs
@@ -36,7 +36,7 @@ fn is_anthropic_overloaded_error(error: &anyhow::Error) -> bool {
         .is_some_and(|e| matches!(e, AnthropicError::OverloadedError { .. }))
 }
 
-fn get_api_status_code(error: &anyhow::Error) -> Option<u16> {
+pub(crate) fn get_api_status_code(error: &anyhow::Error) -> Option<u16> {
     error.downcast_ref::<Error>().and_then(|error| match error {
         Error::Response(error) => error
             .get_code_deep()


### PR DESCRIPTION
## Summary
Fix Codex Responses API 503 handling so retryable HTTP status codes are preserved for the default retry pipeline.

## Context
Codex requests to `https://chatgpt.com/backend-api/codex/responses` can fail with transient `503 Service Unavailable` errors such as upstream connection failures. Although 503 is already part of the default retry status-code configuration, Codex's direct HTTP streaming path converted non-success responses into generic errors, which discarded the status code before retry classification.

## Changes
- Preserve the HTTP status code from non-success Codex Responses API POSTs by wrapping the response as an OpenAI `InvalidStatusCode` error.
- Keep the response body as error context so the original upstream failure reason remains visible.
- Expose the retry status-code extractor within the crate for focused unit coverage.
- Add tests confirming 503 is retained for retry classification and the response body remains available.

### Key Implementation Details
The Codex streaming path now creates a status-aware error before applying the existing HTTP context. The shared retry classifier can then recognize the 503 through the already-configured default retry status codes, while callers still see the upstream error body in the error chain.

## Testing
```bash
cargo test -p forge_config test_retry_config_fields
cargo test -p forge_repo test_status_code_error_preserves
cargo check -p forge_repo
```

## Notes
`cargo fmt` was run; it completed successfully with existing warnings about unstable rustfmt options on the current toolchain.
