### PR TITLE
Add MiMo V2.5 Pro to OpenCode Go

### DIFF
--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -2990,6 +2990,16 @@
         "input_modalities": ["text"]
       },
       {
+        "id": "mimo-v2.5",
+        "name": "MiMo V2.5",
+        "description": "MiMo V2.5 model",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
         "id": "deepseek-v4-flash",
         "name": "DeepSeek V4 Flash",
         "description": "DeepSeek V4 Flash model",

--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -2980,6 +2980,16 @@
     "url": "https://opencode.ai/zen/go",
     "models": [
       {
+        "id": "mimo-v2.5-pro",
+        "name": "MiMo V2.5 Pro",
+        "description": "MiMo V2.5 Pro model",
+        "context_length": 1048576,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
         "id": "deepseek-v4-flash",
         "name": "DeepSeek V4 Flash",
         "description": "DeepSeek V4 Flash model",


### PR DESCRIPTION
## Summary
Add the MiMo V2.5 Pro model to OpenCode Go provider configuration.

## Context
The models.dev OpenCode Go metadata lists `mimo-v2.5-pro` as available. The existing OpenCode Go provider already includes the DeepSeek models from that source, while OpenCode Zen does not list DeepSeek models in models.dev.

## Changes
- Added `mimo-v2.5-pro` to the `opencode_go` provider model list.
- Left all other provider configuration unchanged.

## Testing
```bash
python3 -m json.tool crates/forge_repo/src/provider/provider.json > /dev/null
cargo check -p forge_repo
```
