### PR TITLE
fix(sync): count all files in failed upload batch as failed

### DIFF
--- a/crates/forge_services/src/sync.rs
+++ b/crates/forge_services/src/sync.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 use forge_app::{FileReaderInfra, SyncProgressCounter, WorkspaceStatus, compute_hash};
 use forge_domain::{ApiKey, FileHash, SyncProgress, UserId, WorkspaceId, WorkspaceIndexRepository};
 use futures::stream::{Stream, StreamExt};
+use futures::FutureExt;
 use tracing::{info, warn};
 
 use crate::fd::{FileDiscovery, discover_sync_file_paths};
@@ -171,10 +172,7 @@ impl<F: 'static + WorkspaceIndexRepository + FileReaderInfra, D: FileDiscovery +
         // and each batch is sent in a single HTTP request, sequentially.
         let mut upload_stream = Box::pin(self.upload_files(sync_paths.upload));
 
-        // Process uploads as they complete, updating progress incrementally.
-        // Each item carries the batch's attempted count so that a failed batch
-        // is accounted for as N failed files (not 1) when the batch contains N
-        // files.
+        // Process uploads as they complete, updating progress incrementally
         while let Some((attempted, result)) = upload_stream.next().await {
             match result {
                 Ok(()) => {
@@ -182,7 +180,7 @@ impl<F: 'static + WorkspaceIndexRepository + FileReaderInfra, D: FileDiscovery +
                     emit(counter.sync_progress()).await;
                 }
                 Err(e) => {
-                    warn!(workspace_id = %self.workspace_id, error = ?e, attempted, "Failed to upload batch during sync");
+                    warn!(workspace_id = %self.workspace_id, error = ?e, "Failed to upload file during sync");
                     failed_files += attempted;
                     // Continue processing remaining uploads
                 }
@@ -272,13 +270,8 @@ impl<F: 'static + WorkspaceIndexRepository + FileReaderInfra, D: FileDiscovery +
     /// [`forge_domain::FileUpload`] payload, and uploaded in one request.
     /// Batches are processed sequentially — only one HTTP request is in-flight
     /// at a time — which keeps both memory usage and server concurrency
-    /// bounded.
-    ///
-    /// The stream yields one item per batch as `(attempted, result)`, where
-    /// `attempted` is the number of files in the batch and `result` indicates
-    /// whether the batch upload succeeded. Callers can therefore correctly
-    /// account for all files in a failed batch rather than treating a batch
-    /// failure as a single-file failure.
+    /// bounded. The stream yields the number of files attempted per batch
+    /// along with whether the batch upload succeeded.
     fn upload_files(
         &self,
         paths: Vec<PathBuf>,
@@ -296,36 +289,27 @@ impl<F: 'static + WorkspaceIndexRepository + FileReaderInfra, D: FileDiscovery +
                 let workspace_id = workspace_id.clone();
                 let token = token.clone();
                 let infra = infra.clone();
+                let attempted = batch.len();
                 async move {
-                    let attempted = batch.len();
-                    let result = async {
-                        let mut files = Vec::with_capacity(attempted);
-                        for file_path in &batch {
-                            let content = infra.read_utf8(file_path).await.with_context(|| {
-                                format!(
-                                    "Failed to read file '{}' for upload",
-                                    file_path.display()
-                                )
-                            })?;
-                            files.push(forge_domain::FileRead::new(
-                                file_path.to_string_lossy().into_owned(),
-                                content,
-                            ));
-                        }
-                        let upload = forge_domain::CodeBase::new(
-                            user_id.clone(),
-                            workspace_id.clone(),
-                            files,
-                        );
-                        infra
-                            .upload_files(&upload, &token)
-                            .await
-                            .context("Failed to upload files")?;
-                        Ok::<_, anyhow::Error>(())
+                    let mut files = Vec::with_capacity(batch.len());
+                    for file_path in &batch {
+                        let content = infra.read_utf8(file_path).await.with_context(|| {
+                            format!("Failed to read file '{}' for upload", file_path.display())
+                        })?;
+                        files.push(forge_domain::FileRead::new(
+                            file_path.to_string_lossy().into_owned(),
+                            content,
+                        ));
                     }
-                    .await;
-                    (attempted, result)
+                    let upload =
+                        forge_domain::CodeBase::new(user_id.clone(), workspace_id.clone(), files);
+                    infra
+                        .upload_files(&upload, &token)
+                        .await
+                        .context("Failed to upload files")?;
+                    Ok::<_, anyhow::Error>(())
                 }
+                .map(move |result| (attempted, result))
             })
     }
 

--- a/crates/forge_services/src/sync.rs
+++ b/crates/forge_services/src/sync.rs
@@ -171,16 +171,19 @@ impl<F: 'static + WorkspaceIndexRepository + FileReaderInfra, D: FileDiscovery +
         // and each batch is sent in a single HTTP request, sequentially.
         let mut upload_stream = Box::pin(self.upload_files(sync_paths.upload));
 
-        // Process uploads as they complete, updating progress incrementally
-        while let Some(result) = upload_stream.next().await {
+        // Process uploads as they complete, updating progress incrementally.
+        // Each item carries the batch's attempted count so that a failed batch
+        // is accounted for as N failed files (not 1) when the batch contains N
+        // files.
+        while let Some((attempted, result)) = upload_stream.next().await {
             match result {
-                Ok(count) => {
-                    counter.complete(count);
+                Ok(()) => {
+                    counter.complete(attempted);
                     emit(counter.sync_progress()).await;
                 }
                 Err(e) => {
-                    warn!(workspace_id = %self.workspace_id, error = ?e, "Failed to upload file during sync");
-                    failed_files += 1;
+                    warn!(workspace_id = %self.workspace_id, error = ?e, attempted, "Failed to upload batch during sync");
+                    failed_files += attempted;
                     // Continue processing remaining uploads
                 }
             }
@@ -269,12 +272,17 @@ impl<F: 'static + WorkspaceIndexRepository + FileReaderInfra, D: FileDiscovery +
     /// [`forge_domain::FileUpload`] payload, and uploaded in one request.
     /// Batches are processed sequentially — only one HTTP request is in-flight
     /// at a time — which keeps both memory usage and server concurrency
-    /// bounded. The stream yields the number of files successfully uploaded
-    /// per batch.
+    /// bounded.
+    ///
+    /// The stream yields one item per batch as `(attempted, result)`, where
+    /// `attempted` is the number of files in the batch and `result` indicates
+    /// whether the batch upload succeeded. Callers can therefore correctly
+    /// account for all files in a failed batch rather than treating a batch
+    /// failure as a single-file failure.
     fn upload_files(
         &self,
         paths: Vec<PathBuf>,
-    ) -> impl Stream<Item = Result<usize, anyhow::Error>> + Send {
+    ) -> impl Stream<Item = (usize, Result<(), anyhow::Error>)> + Send {
         let user_id = self.user_id.clone();
         let workspace_id = self.workspace_id.clone();
         let token = self.token.clone();
@@ -289,26 +297,38 @@ impl<F: 'static + WorkspaceIndexRepository + FileReaderInfra, D: FileDiscovery +
                 let token = token.clone();
                 let infra = infra.clone();
                 async move {
-                    let mut files = Vec::with_capacity(batch.len());
-                    for file_path in &batch {
-                        let content = infra.read_utf8(file_path).await.with_context(|| {
-                            format!("Failed to read file '{}' for upload", file_path.display())
-                        })?;
-                        files.push(forge_domain::FileRead::new(
-                            file_path.to_string_lossy().into_owned(),
-                            content,
-                        ));
-                    }
-                    let count = files.len();
-                    let upload =
-                        forge_domain::CodeBase::new(user_id.clone(), workspace_id.clone(), files);
-                    infra
-                        .upload_files(&upload, &token)
-                        .await
-                        .context("Failed to upload files")?;
-                    Ok::<_, anyhow::Error>(count)
+                    let attempted = batch.len();
+                    let result = Self::upload_batch(&infra, &user_id, &workspace_id, &token, batch)
+                        .await;
+                    (attempted, result)
                 }
             })
+    }
+
+    /// Reads and uploads a single batch of files in one HTTP request.
+    async fn upload_batch(
+        infra: &Arc<F>,
+        user_id: &UserId,
+        workspace_id: &WorkspaceId,
+        token: &ApiKey,
+        batch: Vec<PathBuf>,
+    ) -> Result<()> {
+        let mut files = Vec::with_capacity(batch.len());
+        for file_path in &batch {
+            let content = infra.read_utf8(file_path).await.with_context(|| {
+                format!("Failed to read file '{}' for upload", file_path.display())
+            })?;
+            files.push(forge_domain::FileRead::new(
+                file_path.to_string_lossy().into_owned(),
+                content,
+            ));
+        }
+        let upload = forge_domain::CodeBase::new(user_id.clone(), workspace_id.clone(), files);
+        infra
+            .upload_files(&upload, token)
+            .await
+            .context("Failed to upload files")?;
+        Ok(())
     }
 
     /// Discovers workspace files and streams their hashes without retaining

--- a/crates/forge_services/src/sync.rs
+++ b/crates/forge_services/src/sync.rs
@@ -359,3 +359,104 @@ impl<F: 'static + WorkspaceIndexRepository + FileReaderInfra, D: FileDiscovery +
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use async_trait::async_trait;
+    use forge_app::FileReaderInfra;
+    use forge_domain::{
+        ApiKey, FileDeletion, FileHash, FileInfo, FileUpload, FileUploadInfo, Node, UserId,
+        WorkspaceAuth, WorkspaceFiles, WorkspaceId, WorkspaceIndexRepository, WorkspaceInfo,
+    };
+    use futures::StreamExt;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    /// Minimal infra for `upload_files`: only `read_utf8` + `upload_files`
+    /// are exercised; everything else is intentionally unreachable.
+    struct MockInfra {
+        fail_upload: bool,
+    }
+
+    #[async_trait]
+    #[rustfmt::skip]
+    impl FileReaderInfra for MockInfra {
+        async fn read_utf8(&self, _path: &Path) -> anyhow::Result<String> { Ok(String::new()) }
+        fn read_batch_utf8(&self, _: usize, _: Vec<PathBuf>) -> impl futures::Stream<Item = (PathBuf, anyhow::Result<String>)> + Send { futures::stream::empty() }
+        async fn read(&self, _: &Path) -> anyhow::Result<Vec<u8>> { unreachable!() }
+        async fn range_read_utf8(&self, _: &Path, _: u64, _: u64) -> anyhow::Result<(String, FileInfo)> { unreachable!() }
+    }
+
+    #[async_trait]
+    #[rustfmt::skip]
+    impl WorkspaceIndexRepository for MockInfra {
+        async fn upload_files(&self, _: &FileUpload, _: &ApiKey) -> anyhow::Result<FileUploadInfo> {
+            if self.fail_upload { Err(anyhow::anyhow!("boom")) } else { Ok(FileUploadInfo::default()) }
+        }
+        async fn authenticate(&self) -> anyhow::Result<WorkspaceAuth> { unreachable!() }
+        async fn create_workspace(&self, _: &Path, _: &ApiKey) -> anyhow::Result<WorkspaceId> { unreachable!() }
+        async fn search(&self, _: &forge_domain::CodeSearchQuery<'_>, _: &ApiKey) -> anyhow::Result<Vec<Node>> { unreachable!() }
+        async fn list_workspaces(&self, _: &ApiKey) -> anyhow::Result<Vec<WorkspaceInfo>> { unreachable!() }
+        async fn get_workspace(&self, _: &WorkspaceId, _: &ApiKey) -> anyhow::Result<Option<WorkspaceInfo>> { unreachable!() }
+        async fn list_workspace_files(&self, _: &WorkspaceFiles, _: &ApiKey) -> anyhow::Result<Vec<FileHash>> { unreachable!() }
+        async fn delete_files(&self, _: &FileDeletion, _: &ApiKey) -> anyhow::Result<()> { unreachable!() }
+        async fn delete_workspace(&self, _: &WorkspaceId, _: &ApiKey) -> anyhow::Result<()> { unreachable!() }
+    }
+
+    /// Discovery is not invoked by `upload_files`; a no-op satisfies the bound.
+    struct NoDiscovery;
+    #[async_trait]
+    impl FileDiscovery for NoDiscovery {
+        async fn discover(&self, _: &Path) -> anyhow::Result<Vec<PathBuf>> { Ok(vec![]) }
+    }
+
+    fn fixture(fail_upload: bool) -> WorkspaceSyncEngine<MockInfra, NoDiscovery> {
+        WorkspaceSyncEngine::new(
+            Arc::new(MockInfra { fail_upload }),
+            Arc::new(NoDiscovery),
+            PathBuf::new(),
+            WorkspaceId::generate(),
+            UserId::generate(),
+            ApiKey::from(String::new()),
+            3, // batch_size
+        )
+    }
+
+    /// Regression test for the bug where a failed batch counted as 1 failure
+    /// instead of N. With batch_size=3 and 5 files, batches are [3, 2] and
+    /// each must report its full size on failure.
+    #[tokio::test]
+    async fn test_failed_batch_reports_full_batch_size() {
+        let engine = fixture(true);
+        let paths: Vec<PathBuf> = (0..5).map(|i| PathBuf::from(format!("f{i}"))).collect();
+
+        let actual: Vec<(usize, bool)> = engine
+            .upload_files(paths)
+            .map(|(n, r)| (n, r.is_ok()))
+            .collect()
+            .await;
+        let expected = vec![(3, false), (2, false)];
+
+        assert_eq!(actual, expected);
+    }
+
+    /// Successful batches must also yield their full size so the progress
+    /// counter advances correctly.
+    #[tokio::test]
+    async fn test_successful_batch_reports_full_batch_size() {
+        let engine = fixture(false);
+        let paths: Vec<PathBuf> = (0..5).map(|i| PathBuf::from(format!("f{i}"))).collect();
+
+        let actual: Vec<(usize, bool)> = engine
+            .upload_files(paths)
+            .map(|(n, r)| (n, r.is_ok()))
+            .collect()
+            .await;
+        let expected = vec![(3, true), (2, true)];
+
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/forge_services/src/sync.rs
+++ b/crates/forge_services/src/sync.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use forge_app::{FileReaderInfra, SyncProgressCounter, WorkspaceStatus, compute_hash};
 use forge_domain::{ApiKey, FileHash, SyncProgress, UserId, WorkspaceId, WorkspaceIndexRepository};
-use futures::stream::{Stream, StreamExt};
 use futures::FutureExt;
+use futures::stream::{Stream, StreamExt};
 use tracing::{info, warn};
 
 use crate::fd::{FileDiscovery, discover_sync_file_paths};

--- a/crates/forge_services/src/sync.rs
+++ b/crates/forge_services/src/sync.rs
@@ -298,37 +298,35 @@ impl<F: 'static + WorkspaceIndexRepository + FileReaderInfra, D: FileDiscovery +
                 let infra = infra.clone();
                 async move {
                     let attempted = batch.len();
-                    let result = Self::upload_batch(&infra, &user_id, &workspace_id, &token, batch)
-                        .await;
+                    let result = async {
+                        let mut files = Vec::with_capacity(attempted);
+                        for file_path in &batch {
+                            let content = infra.read_utf8(file_path).await.with_context(|| {
+                                format!(
+                                    "Failed to read file '{}' for upload",
+                                    file_path.display()
+                                )
+                            })?;
+                            files.push(forge_domain::FileRead::new(
+                                file_path.to_string_lossy().into_owned(),
+                                content,
+                            ));
+                        }
+                        let upload = forge_domain::CodeBase::new(
+                            user_id.clone(),
+                            workspace_id.clone(),
+                            files,
+                        );
+                        infra
+                            .upload_files(&upload, &token)
+                            .await
+                            .context("Failed to upload files")?;
+                        Ok::<_, anyhow::Error>(())
+                    }
+                    .await;
                     (attempted, result)
                 }
             })
-    }
-
-    /// Reads and uploads a single batch of files in one HTTP request.
-    async fn upload_batch(
-        infra: &Arc<F>,
-        user_id: &UserId,
-        workspace_id: &WorkspaceId,
-        token: &ApiKey,
-        batch: Vec<PathBuf>,
-    ) -> Result<()> {
-        let mut files = Vec::with_capacity(batch.len());
-        for file_path in &batch {
-            let content = infra.read_utf8(file_path).await.with_context(|| {
-                format!("Failed to read file '{}' for upload", file_path.display())
-            })?;
-            files.push(forge_domain::FileRead::new(
-                file_path.to_string_lossy().into_owned(),
-                content,
-            ));
-        }
-        let upload = forge_domain::CodeBase::new(user_id.clone(), workspace_id.clone(), files);
-        infra
-            .upload_files(&upload, token)
-            .await
-            .context("Failed to upload files")?;
-        Ok(())
     }
 
     /// Discovers workspace files and streams their hashes without retaining

--- a/crates/forge_services/src/sync.rs
+++ b/crates/forge_services/src/sync.rs
@@ -410,7 +410,9 @@ mod tests {
     struct NoDiscovery;
     #[async_trait]
     impl FileDiscovery for NoDiscovery {
-        async fn discover(&self, _: &Path) -> anyhow::Result<Vec<PathBuf>> { Ok(vec![]) }
+        async fn discover(&self, _: &Path) -> anyhow::Result<Vec<PathBuf>> {
+            Ok(vec![])
+        }
     }
 
     fn fixture(fail_upload: bool) -> WorkspaceSyncEngine<MockInfra, NoDiscovery> {


### PR DESCRIPTION
## Summary
Fix `failed_files` undercounting when a batch upload fails — a batch of N files was counted as 1 failure instead of N.

## Context
The upload stream processes files in batches of up to `batch_size`. When a batch upload failed, the error handler incremented `failed_files += 1` regardless of how many files were in the batch. With a batch size of 100, a single failed batch would only report 1 failed file instead of 100, causing the final `SyncProgress::Completed` event and the sync error to report incorrect counts.

## Changes
- Changed the `upload_files` stream item type from `Result<usize, Error>` to `(usize, Result<(), Error>)`, so the batch's attempted file count is always available regardless of success or failure
- Capture `attempted = batch.len()` before the async block so it's accessible in both the success and failure branches
- On success: `counter.complete(attempted)` (same as before, now using the tuple)
- On failure: `failed_files += attempted` instead of `+= 1`

## Testing
```bash
cargo check -p forge_services
```
