### PR TITLE
feat: add command-based API key authentication for custom providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ jobs/**
 node_modules/
 bench/__pycache__
 .ai/
+.worktrees/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2480,6 +2480,7 @@ dependencies = [
  "aws-smithy-types",
  "backon",
  "base64 0.22.1",
+ "bstr",
  "bytes",
  "chrono",
  "derive_more",

--- a/crates/forge_config/src/config.rs
+++ b/crates/forge_config/src/config.rs
@@ -44,6 +44,8 @@ pub enum ProviderTypeEntry {
 pub enum ProviderAuthMethod {
     ApiKey,
     GoogleAdc,
+    Command,
+    CommandNoCache,
 }
 
 /// A URL parameter variable for a provider, used to substitute template
@@ -96,6 +98,10 @@ pub struct ProviderEntry {
     /// `["api_key"]` when omitted.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub auth_methods: Vec<ProviderAuthMethod>,
+    /// Shell command that prints an API key / token to stdout.
+    /// Used when `auth_methods` contains `command` or `command_no_cache`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_key_command: Option<String>,
 }
 
 /// Top-level Forge configuration merged from all sources (defaults, file,
@@ -371,5 +377,39 @@ mod tests {
         let actual = ConfigReader::default().read_toml(&toml).build().unwrap();
 
         assert_eq!(actual.temperature, fixture.temperature);
+    }
+
+    #[test]
+    fn test_command_auth_method_deserialize() {
+        let toml = r#"
+            [[providers]]
+            id = "azure-llm"
+            url = "https://my-corp.azure.com/v1/chat/completions"
+            response_type = "OpenAI"
+            auth_methods = ["command"]
+            api_key_command = "az account get-access-token --query accessToken -o tsv"
+        "#;
+        let actual: ForgeConfig = ConfigReader::default().read_toml(toml).build().unwrap();
+        assert_eq!(actual.providers.len(), 1);
+        assert_eq!(actual.providers[0].auth_methods, vec![ProviderAuthMethod::Command]);
+        assert_eq!(
+            actual.providers[0].api_key_command.as_deref(),
+            Some("az account get-access-token --query accessToken -o tsv")
+        );
+    }
+
+    #[test]
+    fn test_command_no_cache_auth_method_deserialize() {
+        let toml = r#"
+            [[providers]]
+            id = "azure-llm"
+            url = "https://my-corp.azure.com/v1/chat/completions"
+            response_type = "OpenAI"
+            auth_methods = ["command_no_cache"]
+            api_key_command = "az account get-access-token --query accessToken -o tsv"
+        "#;
+        let actual: ForgeConfig = ConfigReader::default().read_toml(toml).build().unwrap();
+        assert_eq!(actual.providers.len(), 1);
+        assert_eq!(actual.providers[0].auth_methods, vec![ProviderAuthMethod::CommandNoCache]);
     }
 }

--- a/crates/forge_domain/src/auth/auth_method.rs
+++ b/crates/forge_domain/src/auth/auth_method.rs
@@ -17,6 +17,8 @@ pub enum AuthMethod {
     AwsProfile,
     #[serde(rename = "codex_device")]
     CodexDevice(OAuthConfig),
+    #[serde(rename = "command")]
+    Command { command: String, cache: bool },
 }
 
 impl AuthMethod {
@@ -42,7 +44,7 @@ impl AuthMethod {
             Self::OAuthDevice(config) | Self::OAuthCode(config) | Self::CodexDevice(config) => {
                 Some(config)
             }
-            Self::ApiKey | Self::GoogleAdc | Self::AwsProfile => None,
+            Self::ApiKey | Self::GoogleAdc | Self::AwsProfile | Self::Command { .. } => None,
         }
     }
 }
@@ -112,5 +114,28 @@ mod tests {
             actual.oauth_config().unwrap().client_id.as_str(),
             "app_EMoamEEZ73f0CkXaXp7hrann"
         );
+    }
+
+    #[test]
+    fn test_command_auth_method_serde_roundtrip() {
+        let method = AuthMethod::Command { command: "az token".to_string(), cache: true };
+        let serialized = serde_json::to_string(&method).unwrap();
+        let actual: AuthMethod = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(actual, method);
+    }
+
+    #[test]
+    fn test_command_no_cache_auth_method_serde_roundtrip() {
+        let method = AuthMethod::Command { command: "az token".to_string(), cache: false };
+        let serialized = serde_json::to_string(&method).unwrap();
+        let actual: AuthMethod = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(actual, method);
+    }
+
+    #[test]
+    fn test_command_auth_method_oauth_config_returns_none() {
+        let method = AuthMethod::Command { command: "az token".to_string(), cache: true };
+        let actual = method.oauth_config();
+        assert_eq!(actual, None);
     }
 }

--- a/crates/forge_infra/src/auth/command_strategy.rs
+++ b/crates/forge_infra/src/auth/command_strategy.rs
@@ -1,0 +1,113 @@
+use bstr::ByteSlice;
+use forge_app::AuthStrategy;
+use forge_domain::{
+    ApiKey, ApiKeyRequest, AuthContextRequest, AuthContextResponse, AuthCredential, ProviderId,
+};
+/// Executes a shell command and returns the trimmed stdout as an `ApiKey`.
+pub async fn execute_api_key_command(command: &str) -> anyhow::Result<ApiKey> {
+    let output = tokio::process::Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to execute api_key_command `{command}`: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = output.stderr.as_slice().to_str_lossy();
+        anyhow::bail!(
+            "api_key_command `{command}` exited with {}: {}",
+            output.status,
+            stderr.trim()
+        );
+    }
+
+    let token = String::from_utf8(output.stdout)
+        .map_err(|e| anyhow::anyhow!("api_key_command output is not valid UTF-8: {e}"))?
+        .trim()
+        .to_string();
+
+    if token.is_empty() {
+        anyhow::bail!("api_key_command `{command}` produced no output");
+    }
+
+    Ok(ApiKey::from(token))
+}
+
+/// Auth strategy for command-based authentication.
+/// Auto-resolves by executing the configured command — no user interaction
+/// needed.
+pub struct CommandAuthStrategy {
+    provider_id: ProviderId,
+    command: String,
+}
+
+impl CommandAuthStrategy {
+    /// Creates a new command-based auth strategy for the given provider.
+    pub fn new(provider_id: ProviderId, command: String) -> Self {
+        Self { provider_id, command }
+    }
+}
+
+#[async_trait::async_trait]
+impl AuthStrategy for CommandAuthStrategy {
+    async fn init(&self) -> anyhow::Result<AuthContextRequest> {
+        let api_key = execute_api_key_command(&self.command).await?;
+        Ok(AuthContextRequest::ApiKey(ApiKeyRequest {
+            api_key: Some(api_key),
+            required_params: vec![],
+            existing_params: None,
+        }))
+    }
+
+    async fn complete(
+        &self,
+        _context_response: AuthContextResponse,
+    ) -> anyhow::Result<AuthCredential> {
+        let api_key = execute_api_key_command(&self.command).await?;
+        Ok(AuthCredential::new_api_key(self.provider_id.clone(), api_key))
+    }
+
+    async fn refresh(&self, _credential: &AuthCredential) -> anyhow::Result<AuthCredential> {
+        let api_key = execute_api_key_command(&self.command).await?;
+        Ok(AuthCredential::new_api_key(self.provider_id.clone(), api_key))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_execute_command_returns_trimmed_stdout() {
+        let actual = execute_api_key_command("echo hello-token").await.unwrap();
+        let expected = ApiKey::from("hello-token".to_string());
+        assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn test_execute_command_trims_whitespace() {
+        let actual = execute_api_key_command("echo '  spaced-token  '")
+            .await
+            .unwrap();
+        let expected = ApiKey::from("spaced-token".to_string());
+        assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn test_execute_command_fails_on_bad_exit_code() {
+        let actual = execute_api_key_command("sh -c 'exit 1'").await;
+        assert!(actual.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_execute_command_fails_on_empty_output() {
+        let actual = execute_api_key_command("echo ''").await;
+        assert!(actual.is_err());
+    }
+
+}

--- a/crates/forge_infra/src/auth/mod.rs
+++ b/crates/forge_infra/src/auth/mod.rs
@@ -1,3 +1,4 @@
+pub mod command_strategy;
 mod mcp_credentials;
 mod mcp_token_storage;
 

--- a/crates/forge_infra/src/auth/strategy.rs
+++ b/crates/forge_infra/src/auth/strategy.rs
@@ -12,6 +12,7 @@ use oauth2::{ClientId, DeviceAuthorizationUrl, Scope, TokenUrl};
 use reqwest::header::{HeaderMap, HeaderValue};
 use url::Url;
 
+use crate::auth::command_strategy::CommandAuthStrategy;
 use crate::auth::error::Error as AuthError;
 use crate::auth::http::{AnthropicHttpProvider, GithubHttpProvider, StandardHttpProvider};
 use crate::auth::util::*;
@@ -1077,6 +1078,7 @@ pub enum AnyAuthStrategy {
     GoogleAdc(GoogleAdcStrategy),
     AwsProfile(AwsProfileStrategy),
     CodexDevice(CodexDeviceStrategy),
+    Command(CommandAuthStrategy),
 }
 
 #[async_trait::async_trait]
@@ -1092,6 +1094,7 @@ impl AuthStrategy for AnyAuthStrategy {
             Self::GoogleAdc(s) => s.init().await,
             Self::AwsProfile(s) => s.init().await,
             Self::CodexDevice(s) => s.init().await,
+            Self::Command(s) => s.init().await,
         }
     }
 
@@ -1109,6 +1112,7 @@ impl AuthStrategy for AnyAuthStrategy {
             Self::GoogleAdc(s) => s.complete(context_response).await,
             Self::AwsProfile(s) => s.complete(context_response).await,
             Self::CodexDevice(s) => s.complete(context_response).await,
+            Self::Command(s) => s.complete(context_response).await,
         }
     }
 
@@ -1123,6 +1127,7 @@ impl AuthStrategy for AnyAuthStrategy {
             Self::GoogleAdc(s) => s.refresh(credential).await,
             Self::AwsProfile(s) => s.refresh(credential).await,
             Self::CodexDevice(s) => s.refresh(credential).await,
+            Self::Command(s) => s.refresh(credential).await,
         }
     }
 }
@@ -1201,6 +1206,12 @@ impl StrategyFactory for ForgeAuthStrategyFactory {
             forge_domain::AuthMethod::CodexDevice(config) => Ok(AnyAuthStrategy::CodexDevice(
                 CodexDeviceStrategy::new(provider_id, config),
             )),
+            forge_domain::AuthMethod::Command { command, .. } => {
+                Ok(AnyAuthStrategy::Command(CommandAuthStrategy::new(
+                    provider_id,
+                    command,
+                )))
+            }
         }
     }
 }

--- a/crates/forge_infra/src/lib.rs
+++ b/crates/forge_infra/src/lib.rs
@@ -1,4 +1,4 @@
-mod auth;
+pub mod auth;
 mod console;
 mod env;
 mod error;

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -3240,6 +3240,7 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                 AuthMethod::GoogleAdc => "Google Application Default Credentials (ADC)".to_string(),
                 AuthMethod::AwsProfile => "AWS Profile (SSO/IAM)".to_string(),
                 AuthMethod::CodexDevice(_) => "OpenAI Codex Device Flow".to_string(),
+                AuthMethod::Command { .. } => "Command-based Authentication".to_string(),
             })
             .collect();
 

--- a/crates/forge_repo/Cargo.toml
+++ b/crates/forge_repo/Cargo.toml
@@ -14,6 +14,7 @@ forge_fs.workspace = true
 forge_template.workspace = true
 forge_json_repair.workspace = true
 anyhow.workspace = true
+bstr.workspace = true
 backon.workspace = true
 futures.workspace = true
 async-trait.workspace = true

--- a/crates/forge_repo/src/provider/openai.rs
+++ b/crates/forge_repo/src/provider/openai.rs
@@ -99,6 +99,7 @@ impl<H: HttpInfra> OpenAIProvider<H> {
                 }
                 forge_domain::AuthMethod::GoogleAdc => {}
                 forge_domain::AuthMethod::AwsProfile => {}
+                forge_domain::AuthMethod::Command { .. } => {}
             });
         // Append provider-level custom headers (from provider.json config)
         if let Some(custom_headers) = &self.provider.custom_headers {

--- a/crates/forge_repo/src/provider/openai_responses/repository.rs
+++ b/crates/forge_repo/src/provider/openai_responses/repository.rs
@@ -119,6 +119,7 @@ impl<H: HttpInfra> OpenAIResponsesProvider<H> {
                 }
                 forge_domain::AuthMethod::GoogleAdc => {}
                 forge_domain::AuthMethod::AwsProfile => {}
+                forge_domain::AuthMethod::Command { .. } => {}
             });
 
         // Codex provider requires the ChatGPT-Account-Id header extracted

--- a/crates/forge_repo/src/provider/provider_repo.rs
+++ b/crates/forge_repo/src/provider/provider_repo.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::{Arc, LazyLock};
 
 use bytes::Bytes;
@@ -149,6 +150,7 @@ impl From<forge_config::ProviderEntry> for ProviderConfig {
             Some(forge_config::ProviderTypeEntry::Llm) | None => forge_domain::ProviderType::Llm,
         };
 
+        let api_key_command = entry.api_key_command.clone();
         let auth_methods = if entry.auth_methods.is_empty() {
             vec![forge_domain::AuthMethod::ApiKey]
         } else {
@@ -159,6 +161,22 @@ impl From<forge_config::ProviderEntry> for ProviderConfig {
                     forge_config::ProviderAuthMethod::ApiKey => forge_domain::AuthMethod::ApiKey,
                     forge_config::ProviderAuthMethod::GoogleAdc => {
                         forge_domain::AuthMethod::GoogleAdc
+                    }
+                    forge_config::ProviderAuthMethod::Command => {
+                        forge_domain::AuthMethod::Command {
+                            command: api_key_command
+                                .clone()
+                                .unwrap_or_default(),
+                            cache: true,
+                        }
+                    }
+                    forge_config::ProviderAuthMethod::CommandNoCache => {
+                        forge_domain::AuthMethod::Command {
+                            command: api_key_command
+                                .clone()
+                                .unwrap_or_default(),
+                            cache: false,
+                        }
                     }
                 })
                 .collect()
@@ -229,15 +247,19 @@ fn get_provider_configs() -> &'static Vec<ProviderConfig> {
     &PROVIDER_CONFIGS
 }
 
+/// Repository that resolves provider configurations and credentials.
 pub struct ForgeProviderRepository<F> {
     infra: Arc<F>,
+    /// Per-provider cache for tokens obtained via `api_key_command`.
+    command_token_cache: tokio::sync::Mutex<HashMap<ProviderId, ApiKey>>,
 }
 
 impl<F: EnvironmentInfra<Config = forge_config::ForgeConfig> + HttpInfra>
     ForgeProviderRepository<F>
 {
+    /// Creates a new provider repository backed by the given infrastructure.
     pub fn new(infra: Arc<F>) -> Self {
-        Self { infra }
+        Self { infra, command_token_cache: tokio::sync::Mutex::new(HashMap::new()) }
     }
 }
 
@@ -279,8 +301,34 @@ impl<
                 continue;
             }
 
-            // Try to create configured template provider, fallback to unconfigured
-            let provider_entry = if let Ok(provider) = self.create_provider(&config).await {
+            // Check for command-based auth
+            let command_auth = config.auth_methods.iter().find_map(|m| match m {
+                forge_domain::AuthMethod::Command { command, cache } => {
+                    Some((command.clone(), *cache))
+                }
+                _ => None,
+            });
+
+            let provider_entry = if let Some((command, cache)) = command_auth {
+                match self
+                    .resolve_command_credential(&config, &command, cache)
+                    .await
+                {
+                    Ok(credential) => self
+                        .create_provider_with_credential(&config, credential)
+                        .ok()
+                        .map(AnyProvider::from),
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to resolve command auth for {}: {e}",
+                            config.id
+                        );
+                        self.create_unconfigured_provider(&config)
+                            .ok()
+                            .map(Into::into)
+                    }
+                }
+            } else if let Ok(provider) = self.create_provider(&config).await {
                 Some(provider.into())
             } else if let Ok(provider) = self.create_unconfigured_provider(&config) {
                 Some(provider.into())
@@ -470,6 +518,60 @@ impl<
         config: &ProviderConfig,
     ) -> anyhow::Result<forge_domain::ProviderTemplate> {
         Ok(config.into())
+    }
+
+    /// Creates a provider with a pre-resolved credential (e.g. from command auth).
+    fn create_provider_with_credential(
+        &self,
+        config: &ProviderConfig,
+        credential: AuthCredential,
+    ) -> anyhow::Result<forge_domain::ProviderTemplate> {
+        let models = config.models.as_ref().map(|m| match m {
+            Models::Url(model_url_template) => forge_domain::ModelSource::Url(
+                forge_domain::Template::<forge_domain::URLParameters>::new(model_url_template),
+            ),
+            Models::Hardcoded(model_list) => {
+                forge_domain::ModelSource::Hardcoded(model_list.clone())
+            }
+        });
+
+        Ok(Provider {
+            id: config.id.clone(),
+            provider_type: config.provider_type,
+            response: config.response_type.clone(),
+            url: forge_domain::Template::<forge_domain::URLParameters>::new(&config.url),
+            auth_methods: config.auth_methods.clone(),
+            url_params: config
+                .url_param_vars
+                .iter()
+                .map(|v| v.clone().into_spec())
+                .collect(),
+            credential: Some(credential),
+            custom_headers: config.custom_headers.clone(),
+            models,
+        })
+    }
+
+    /// Resolves a credential by executing a shell command.
+    async fn resolve_command_credential(
+        &self,
+        config: &ProviderConfig,
+        command: &str,
+        cache: bool,
+    ) -> anyhow::Result<AuthCredential> {
+        let api_key = if cache {
+            let mut token_cache = self.command_token_cache.lock().await;
+            if let Some(cached) = token_cache.get(&config.id) {
+                cached.clone()
+            } else {
+                let key = forge_infra::auth::command_strategy::execute_api_key_command(command).await?;
+                token_cache.insert(config.id.clone(), key.clone());
+                key
+            }
+        } else {
+            forge_infra::auth::command_strategy::execute_api_key_command(command).await?
+        };
+        Ok(AuthCredential::new_api_key(config.id.clone(), api_key))
     }
 
     /// Refreshes a Google ADC credential by fetching a fresh token

--- a/crates/forge_services/src/provider_auth.rs
+++ b/crates/forge_services/src/provider_auth.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use bstr::ByteSlice;
 use forge_app::{AuthStrategy, ProviderAuthService, StrategyFactory};
 use forge_domain::{
     AuthContextRequest, AuthContextResponse, AuthMethod, Provider, ProviderId, ProviderRepository,
@@ -16,6 +17,39 @@ impl<I> ForgeProviderAuthService<I> {
     /// Create a new provider authentication service
     pub fn new(infra: Arc<I>) -> Self {
         Self { infra }
+    }
+
+    /// Execute an api_key_command and return the trimmed output as an ApiKey.
+    async fn execute_api_key_command(command: &str) -> anyhow::Result<forge_domain::ApiKey> {
+        let output = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to execute api_key_command `{command}`: {e}"))?;
+
+        if !output.status.success() {
+            let stderr = output.stderr.as_slice().to_str_lossy();
+            anyhow::bail!(
+                "api_key_command `{command}` exited with {}: {}",
+                output.status,
+                stderr.trim()
+            );
+        }
+
+        let token = String::from_utf8(output.stdout)
+            .map_err(|e| anyhow::anyhow!("api_key_command output is not valid UTF-8: {e}"))?
+            .trim()
+            .to_string();
+
+        if token.is_empty() {
+            anyhow::bail!("api_key_command `{command}` produced no output");
+        }
+
+        Ok(forge_domain::ApiKey::from(token))
     }
 }
 
@@ -33,7 +67,10 @@ where
         // Get required URL parameters for API key flow and Google ADC
         let required_params = if matches!(
             auth_method,
-            AuthMethod::ApiKey | AuthMethod::GoogleAdc | AuthMethod::AwsProfile
+            AuthMethod::ApiKey
+                | AuthMethod::GoogleAdc
+                | AuthMethod::AwsProfile
+                | AuthMethod::Command { .. }
         ) {
             // Get URL params from provider entry (works for both configured and
             // unconfigured)
@@ -147,6 +184,30 @@ where
         &self,
         mut provider: Provider<url::Url>,
     ) -> anyhow::Result<Provider<url::Url>> {
+        // Handle command_no_cache: always re-execute regardless of needs_refresh
+        for auth_method in &provider.auth_methods {
+            if let AuthMethod::Command { command, cache: false } = auth_method {
+                match Self::execute_api_key_command(command).await {
+                    Ok(api_key) => {
+                        provider.credential = Some(
+                            forge_domain::AuthCredential::new_api_key(
+                                provider.id.clone(),
+                                api_key,
+                            ),
+                        );
+                        return Ok(provider);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to refresh command auth for {}: {e}",
+                            provider.id
+                        );
+                        // Continue with existing credential
+                    }
+                }
+            }
+        }
+
         // Check if credential needs refresh (5 minute buffer before expiry)
         if let Some(credential) = &provider.credential {
             let buffer = chrono::Duration::minutes(5);

--- a/forge.schema.json
+++ b/forge.schema.json
@@ -633,13 +633,22 @@
       "type": "string",
       "enum": [
         "api_key",
-        "google_adc"
+        "google_adc",
+        "command",
+        "command_no_cache"
       ]
     },
     "ProviderEntry": {
       "description": "A single provider entry defined inline in `forge.toml`.\n\nInline providers are merged with the built-in provider list; entries with\nthe same `id` override the corresponding built-in entry field-by-field,\nwhile entries with a new `id` are appended to the list.",
       "type": "object",
       "properties": {
+        "api_key_command": {
+          "description": "Shell command that prints an API key / token to stdout.\nUsed when `auth_methods` contains `command` or `command_no_cache`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "api_key_var": {
           "description": "Environment variable holding the API key for this provider.",
           "type": [


### PR DESCRIPTION
# Motivation

At my job we work with self-hosted LLMs and need our AI harness to be able to handle that our credentials for authentication are short lived.

Hence I propose this PR so that users can provide API keys via commands that have the result either cached or not.

This opens the door to users being able to store their API keys in password managers like 1password and read the API keys at runtime (yes, they can already do this by running something like `OPENAI_API_KEY=$(op item ...) forge` but this makes that experience a little cleaner.

## Summary

- Adds `command` and `command_no_cache` variants to `auth_methods` for custom providers, allowing users to specify a shell command (`api_key_command`) that produces an API key on stdout
- `command` executes once and caches the token for the session; `command_no_cache` re-executes before every LLM request — designed for short-lived tokens (e.g. Azure AD access tokens)
- Integrates into the existing auth strategy pattern (`CommandAuthStrategy`), provider loading flow, and credential refresh path

## Configuration

```toml
[[providers]]
id              = "llm-with-azure-auth"
url             = "https://self-hosted-llms.mycorp.com/v1/chat/completions"
models          = "https://self-hosted-llms.mycorp.com/v1/models"
response_type   = "OpenAI"
auth_methods    = ["command_no_cache"] # or 'command'
api_key_command = "az account get-access-token --query accessToken -o tsv"
```

## Test plan

- [x] Unit tests for `execute_api_key_command` (trimming, whitespace, bad exit code, empty output)
- [x] Serde roundtrip tests for `AuthMethod::Command` variant
- [x] Config deserialization tests for `command` and `command_no_cache` auth methods
- [x] All 2584 existing tests pass, clippy clean
- [x] Manual testing with Azure AD token provider (`az account get-access-token`)