### PR TITLE
fix(#3191) Update family detection for Opus 4.7 on AskSage

### DIFF
--- a/crates/forge_app/src/transformers/model_specific_reasoning.rs
+++ b/crates/forge_app/src/transformers/model_specific_reasoning.rs
@@ -27,7 +27,7 @@ impl ModelSpecificReasoning {
 
     fn family(&self) -> AnthropicModelFamily {
         let id = self.model_id.to_lowercase();
-        if id.contains("opus-4-7") {
+        if id.contains("opus-4-7") || id.contains("47-opus") {
             AnthropicModelFamily::AdaptiveOnly
         } else if id.contains("opus-4-6") || id.contains("sonnet-4-6") {
             AnthropicModelFamily::AdaptiveFriendly


### PR DESCRIPTION
Claude Opus 4.7 detection wasn't working for AskSage whose Claude 4.7 model is named `google-claude-47-opus`. This patch fixes that detection.

fixes: #3191