### PR TITLE
fix(provider): apply MergeSystemMessages for vLLM provider

### DIFF
--- a/crates/forge_app/src/dto/openai/transformers/ensure_system_first.rs
+++ b/crates/forge_app/src/dto/openai/transformers/ensure_system_first.rs
@@ -5,8 +5,9 @@ use crate::dto::openai::{Message, MessageContent, Request, Role};
 /// Merges all system messages into a single system message at the beginning of
 /// the messages array.
 ///
-/// Some providers (e.g. NVIDIA) reject requests with multiple system messages
-/// or system messages that are not positioned at the start of the conversation.
+/// Some providers (e.g. NVIDIA, vLLM) reject requests with multiple system
+/// messages or system messages that are not positioned at the start of the
+/// conversation.
 pub struct MergeSystemMessages;
 
 impl Transformer for MergeSystemMessages {

--- a/crates/forge_app/src/dto/openai/transformers/pipeline.rs
+++ b/crates/forge_app/src/dto/openai/transformers/pipeline.rs
@@ -82,8 +82,9 @@ impl Transformer for ProviderPipeline<'_> {
 
         let xai_compat = MakeXaiCompat.when(move |_| provider.id == ProviderId::XAI);
 
-        let ensure_system_first =
-            MergeSystemMessages.when(move |_| provider.id == ProviderId::NVIDIA);
+        let vllm = ProviderId::from_str("vllm").unwrap();
+        let ensure_system_first = MergeSystemMessages
+            .when(move |_| provider.id == ProviderId::NVIDIA || provider.id == vllm);
 
         let trim_tool_call_ids = TrimToolCallIds.when(move |_| provider.id == ProviderId::OPENAI);
 
@@ -171,6 +172,7 @@ mod tests {
 
     use super::*;
     use crate::domain::{ModelSource, ProviderResponse};
+    use crate::dto::openai::{Message, MessageContent, Role};
 
     // Test helper functions
     fn make_credential(provider_id: ProviderId, key: &str) -> Option<forge_domain::AuthCredential> {
@@ -244,6 +246,21 @@ mod tests {
             models: Some(ModelSource::Url(
                 Url::parse("https://api.openai.com/v1/models").unwrap(),
             )),
+        }
+    }
+
+    fn vllm(key: &str) -> Provider<Url> {
+        let id = ProviderId::from_str("vllm").unwrap();
+        Provider {
+            id: id.clone(),
+            provider_type: Default::default(),
+            response: Some(ProviderResponse::OpenAI),
+            url: Url::parse("http://localhost:8000/v1/chat/completions").unwrap(),
+            auth_methods: vec![forge_domain::AuthMethod::ApiKey],
+            url_params: vec![],
+            credential: make_credential(id, key),
+            custom_headers: None,
+            models: Some(ModelSource::Hardcoded(vec![])),
         }
     }
 
@@ -369,6 +386,21 @@ mod tests {
         }
     }
 
+    fn message(role: Role, content: &str) -> Message {
+        Message {
+            role,
+            content: Some(MessageContent::Text(content.to_string())),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+            reasoning_details: None,
+            reasoning_text: None,
+            reasoning_opaque: None,
+            reasoning_content: None,
+            extra_content: None,
+        }
+    }
+
     #[test]
     fn test_supports_open_router_params() {
         assert!(supports_open_router_params(&forge("forge")));
@@ -448,6 +480,31 @@ mod tests {
         assert_eq!(actual.thinking, None);
         // OpenAI compat transformer removes reasoning field
         assert_eq!(actual.reasoning, None);
+    }
+
+    #[test]
+    fn test_vllm_provider_merges_system_messages() {
+        let provider = vllm("vllm");
+        let fixture = Request::default().messages(vec![
+            message(Role::User, "hello"),
+            message(Role::System, "you are helpful"),
+            message(Role::Assistant, "hi"),
+            message(Role::System, "be concise"),
+        ]);
+
+        let mut pipeline = ProviderPipeline::new(&provider);
+        let actual = pipeline.transform(fixture).messages.unwrap();
+
+        assert_eq!(actual.len(), 3);
+        assert_eq!(actual[0].role, Role::System);
+        assert_eq!(
+            actual[0].content.as_ref(),
+            Some(&MessageContent::Text(
+                "you are helpful\n\nbe concise".to_string()
+            ))
+        );
+        assert_eq!(actual[1].role, Role::User);
+        assert_eq!(actual[2].role, Role::Assistant);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Apply `MergeSystemMessages` to the vLLM built-in provider in addition to NVIDIA. vLLM rejects requests where the system message is not first, which is exactly what this transformer was built to handle.

## Why this matters

[Issue #3128](https://github.com/tailcallhq/forgecode/issues/3128) reports vLLM serving `mlx-community/Qwen3.6-27B-bf16` rejects every request with:

```
ERROR: POST http://1.2.3.4:8000/v1/chat/completions
Caused by: 404 Not Found Reason: {"error": "System message must be at the beginning."}
```

`MergeSystemMessages` already exists for this case. The transformer doc comment even says "Some providers (e.g. NVIDIA) reject requests with multiple system messages or system messages that are not positioned at the start". The "e.g." anticipated more cases, but the gating predicate at `crates/forge_app/src/dto/openai/transformers/pipeline.rs:86` only matched NVIDIA.

vLLM is a built-in provider (registered in `crates/forge_repo/src/provider/provider.json` as id `"vllm"`), so it has its own `ProviderId` and goes through the openai pipeline. The fix adds it to the same predicate.

## Changes

- `crates/forge_app/src/dto/openai/transformers/pipeline.rs`: predicate now matches `ProviderId::NVIDIA` or the vLLM provider id (resolved via `ProviderId::from_str("vllm")` in the same style as the existing `kimi_coding` binding a few lines below).
- `crates/forge_app/src/dto/openai/transformers/ensure_system_first.rs`: doc comment now lists vLLM alongside NVIDIA.

The transformer is a no-op for already-compliant requests (single system message at the start), so no behavior changes for users whose vLLM server already gets correct input.

## Testing

- New pipeline-level test `test_vllm_provider_merges_system_messages` asserts that a vLLM provider with mixed system messages produces a single merged system message at the front.
- `cargo test -p forge_app`: 696 passed, 0 failed.
- `cargo clippy -p forge_app --all-targets --all-features -- -D warnings`: clean.

Closes #3128

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)