### PR TITLE
fix(update): add UpdateFrequency::Never to opt out of update checks

### DIFF
--- a/crates/forge_config/src/compact.rs
+++ b/crates/forge_config/src/compact.rs
@@ -13,6 +13,7 @@ use crate::Percentage;
 pub enum UpdateFrequency {
     Daily,
     Weekly,
+    Never,
     #[default]
     Always,
 }
@@ -22,6 +23,7 @@ impl From<UpdateFrequency> for Duration {
         match val {
             UpdateFrequency::Daily => Duration::from_secs(60 * 60 * 24),
             UpdateFrequency::Weekly => Duration::from_secs(60 * 60 * 24 * 7),
+            UpdateFrequency::Never => Duration::MAX,
             UpdateFrequency::Always => Duration::ZERO,
         }
     }
@@ -33,7 +35,7 @@ impl From<UpdateFrequency> for Duration {
 )]
 #[setters(strip_option, into)]
 pub struct Update {
-    /// How frequently forge checks for updates
+    /// How frequently forge checks for updates: daily, weekly, always, or never
     pub frequency: Option<UpdateFrequency>,
     /// Whether to automatically install updates without prompting
     pub auto_update: Option<bool>,
@@ -234,5 +236,31 @@ mod tests {
             "expected error for eviction_window = 1.5, got: {:?}",
             result.ok()
         );
+    }
+
+    #[test]
+    fn test_update_frequency_never_round_trip() {
+        let fixture =
+            ForgeConfig::default().updates(Update::default().frequency(UpdateFrequency::Never));
+
+        let toml = toml_edit::ser::to_string_pretty(&fixture).unwrap();
+
+        assert!(
+            toml.contains("frequency = \"never\"\n"),
+            "expected `frequency = \"never\"` in TOML output, got:\n{toml}"
+        );
+
+        let actual = ConfigReader::default()
+            .read_defaults()
+            .read_toml(&toml)
+            .build()
+            .unwrap();
+
+        let expected = Some(
+            Update::default()
+                .frequency(UpdateFrequency::Never)
+                .auto_update(true),
+        );
+        assert_eq!(actual.updates, expected);
     }
 }

--- a/crates/forge_domain/src/update.rs
+++ b/crates/forge_domain/src/update.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 pub enum UpdateFrequency {
     Daily,
     Weekly,
+    Never,
     #[default]
     Always,
 }
@@ -19,7 +20,8 @@ impl From<UpdateFrequency> for Duration {
         match val {
             UpdateFrequency::Daily => Duration::from_secs(60 * 60 * 24), // 1 day
             UpdateFrequency::Weekly => Duration::from_secs(60 * 60 * 24 * 7), // 1 week
-            UpdateFrequency::Always => Duration::ZERO,                   // one time,
+            UpdateFrequency::Never => Duration::MAX,
+            UpdateFrequency::Always => Duration::ZERO, // one time,
         }
     }
 }

--- a/crates/forge_main/src/update.rs
+++ b/crates/forge_main/src/update.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use colored::Colorize;
 use forge_api::API;
-use forge_config::Update;
+use forge_config::{Update, UpdateFrequency};
 use forge_select::ForgeWidget;
 use forge_tracker::VERSION;
 use update_informer::{Check, Version, registry};
@@ -65,10 +65,19 @@ async fn confirm_update(version: Version) -> bool {
     }
 }
 
+fn should_check_for_updates(frequency: &UpdateFrequency) -> bool {
+    !matches!(frequency, UpdateFrequency::Never)
+}
+
 /// Checks if there is an update available
 pub async fn on_update(api: Arc<impl API>, update: Option<&Update>) {
     let update = update.cloned().unwrap_or_default();
     let frequency = update.frequency.unwrap_or_default();
+
+    if !should_check_for_updates(&frequency) {
+        return;
+    }
+
     let auto_update = update.auto_update.unwrap_or_default();
 
     // Check if version is development version, in which case we skip the update
@@ -93,4 +102,21 @@ async fn send_update_failure_event(error_msg: &str) -> anyhow::Result<()> {
     tracing::error!(error = error_msg, "Update failed");
     // Always return Ok since we want to fail silently
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn test_should_skip_update_check_when_frequency_is_never() {
+        let fixture = UpdateFrequency::Never;
+
+        let actual = should_check_for_updates(&fixture);
+
+        let expected = false;
+        assert_eq!(actual, expected);
+    }
 }

--- a/forge.schema.json
+++ b/forge.schema.json
@@ -892,7 +892,7 @@
           ]
         },
         "frequency": {
-          "description": "How frequently forge checks for updates",
+          "description": "How frequently forge checks for updates: daily, weekly, always, or never",
           "anyOf": [
             {
               "$ref": "#/$defs/UpdateFrequency"
@@ -910,6 +910,7 @@
       "enum": [
         "daily",
         "weekly",
+        "never",
         "always"
       ]
     },


### PR DESCRIPTION
## Summary

Add `UpdateFrequency::Never` so users can opt out of forge's auto-update version check. Today the `[update] frequency` enum has only `daily`, `weekly`, and `always`, and `auto_update: false` doesn't help because the version check itself blocks before any prompt fires.

## Why this matters

The reporter on [#3119](https://github.com/tailcallhq/forgecode/issues/3119) explains the use case: low-internet / OTG users want to bring up forge to check configuration or chat history without waiting on the GitHub-side update check. Setting `auto_update: false` only suppresses the install prompt - the HTTP round-trip to `update_informer` still runs unconditionally inside `on_update`, so users in poor-network conditions still pay the wall-clock cost.

There was no escape value before this PR: `frequency = "always"` means "check every time", `daily` and `weekly` still hit the network on the first invocation per window, and there was no `never`.

Closes #3119. (issue: https://github.com/tailcallhq/forgecode/issues/3119)

## Testing

- `cargo test -p forge_domain -p forge_config -p forge_main` -> 951 pass, 13 ignored. Includes a new round-trip test in `compact.rs` for `[update] frequency = "never"` and a new test in `update.rs` that asserts the early-return guard short-circuits before the informer.
- `cargo clippy -p forge_domain -p forge_config -p forge_main --all-features --all-targets -- -D warnings` -> clean
- `cargo clippy --all-features --workspace -- -D clippy::string_slice -D clippy::indexing_slicing -D clippy::disallowed_methods` -> clean

This contribution was developed with AI assistance.

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
