### PR TITLE
fix update PATH export drift

### DIFF
--- a/crates/forge_main/src/update.rs
+++ b/crates/forge_main/src/update.rs
@@ -7,14 +7,21 @@ use forge_select::ForgeWidget;
 use forge_tracker::VERSION;
 use update_informer::{Check, Version, registry};
 
+/// Returns the shell command used for updating Forge.
+///
+/// The hosted installer owns initial PATH setup, but update should only replace
+/// the binary. Filtering the installer PATH persistence call keeps `forge
+/// update` from rewriting shell startup files on every run.
+fn update_command() -> &'static str {
+    "curl -fsSL https://forgecode.dev/cli | sed '/^ensure_install_dir_shell_path$/d' | sh"
+}
+
 /// Runs the official installation script to update Forge, failing silently.
 /// When `auto_update` is true, exits immediately after a successful update
 /// without prompting the user.
 async fn execute_update_command(api: Arc<impl API>, auto_update: bool) {
     // Spawn a new task that won't block the main application
-    let output = api
-        .execute_shell_command_raw("curl -fsSL https://forgecode.dev/cli | sh")
-        .await;
+    let output = api.execute_shell_command_raw(update_command()).await;
 
     match output {
         Err(err) => {
@@ -109,6 +116,16 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
+
+    #[test]
+    fn test_update_command_skips_installer_shell_path_mutation() {
+        let fixture = update_command();
+
+        let actual = fixture.contains("sed '/^ensure_install_dir_shell_path$/d'");
+
+        let expected = true;
+        assert_eq!(actual, expected);
+    }
 
     #[test]
     fn test_should_skip_update_check_when_frequency_is_never() {


### PR DESCRIPTION
## Summary
- Fixes `forge update` so it no longer runs the hosted installer's shell rc PATH persistence step.
- Keeps update behavior focused on replacing the Forge binary while avoiding repeated `.zshrc` / `.bashrc` rewrites.
- Adds targeted coverage that the update command filters the installer `ensure_install_dir_shell_path` invocation.

Fixes #3177

## Repro
Confirmed locally using an isolated temp `$HOME`:
1. Created a temp `.zshrc` representing a dotfile-managed file.
2. Added `$HOME/.local/bin` to a temp `.zprofile`.
3. Ran the installer path function that calls `ensure_install_dir_shell_path`.
4. Observed the hosted installer prepending standalone Forge installer PATH lines outside the existing `>>> forge initialize >>>` block.

## Corrected approach
This PR now avoids adding a new installer script file to the repo. The repo-native update path is `crates/forge_main/src/update.rs`, where `forge update` shells out to `curl -fsSL https://forgecode.dev/cli | sh`.

The minimal in-repo fix is to filter the standalone `ensure_install_dir_shell_path` invocation out of that hosted installer stream during updates. Initial installs still use the hosted installer as before, but updates no longer mutate shell rc files every time.

## Verification
- [x] Ran targeted Rust tests: `cargo test -p forge_main update::tests`
- [x] Ran `cargo check -p forge_main`
- [x] Ran `cargo +nightly fmt --check`

Co-Authored-By: ForgeCode <noreply@forgecode.dev>