### PR TITLE
fix(zsh): clear zsh-autosuggestions POSTDISPLAY on forge-accept-line

### DIFF
--- a/shell-plugin/lib/bindings.zsh
+++ b/shell-plugin/lib/bindings.zsh
@@ -43,3 +43,25 @@ bindkey '^M' forge-accept-line
 bindkey '^J' forge-accept-line
 # Update the Tab binding to use the new completion widget
 bindkey '^I' forge-completion  # Tab for both @ and :command completion
+
+# Integrate with zsh-autosuggestions.
+#
+# zsh-autosuggestions wraps widgets listed in ZSH_AUTOSUGGEST_CLEAR_WIDGETS,
+# ZSH_AUTOSUGGEST_ACCEPT_WIDGETS, etc. so it can clear POSTDISPLAY (the gray
+# inline suggestion) before the widget runs. The wrapping happens once, when
+# autosuggestions loads. If Forge's plugin is sourced *after* autosuggestions
+# (the Oh-My-Zsh default when users follow `forge zsh setup`), our
+# forge-accept-line widget is defined too late to be wrapped, and the inline
+# suggestion lingers on the screen after the user presses Enter.
+#
+# Fix: append forge-accept-line to ZSH_AUTOSUGGEST_CLEAR_WIDGETS and re-run
+# the bind pass so the wrapper is installed. Safe no-op when autosuggestions
+# is not loaded or when the widget is already registered.
+if typeset -p ZSH_AUTOSUGGEST_CLEAR_WIDGETS >/dev/null 2>&1; then
+    if [[ ${ZSH_AUTOSUGGEST_CLEAR_WIDGETS[(Ie)forge-accept-line]} -eq 0 ]]; then
+        ZSH_AUTOSUGGEST_CLEAR_WIDGETS+=(forge-accept-line)
+        if typeset -f _zsh_autosuggest_bind_widgets >/dev/null 2>&1; then
+            _zsh_autosuggest_bind_widgets
+        fi
+    fi
+fi


### PR DESCRIPTION
## Summary

Fixes the grayed-out `zsh-autosuggestions` inline suggestion lingering on screen after Enter is pressed.

Closes #3243.

## Problem

With `zsh-autosuggestions` (listed as a required plugin by `forge zsh doctor`) enabled, the gray inline suggestion stays visible on the screen after you press Enter — overlapping the next prompt / command output. It only goes away on the next keystroke that forces a redraw.

## Root cause

`zsh-autosuggestions` wraps widgets listed in `ZSH_AUTOSUGGEST_CLEAR_WIDGETS` during its one-shot bind pass, so the wrapper can reset `POSTDISPLAY` (the ghost text) before the widget fires. That list includes `accept-line`, `accept-and-hold`, etc. by default — but not `forge-accept-line`, because that widget doesn't exist at autosuggestions-init time.

Under the standard OMZ setup produced by `forge zsh setup`, the load order is:

1. OMZ loads its plugin list → `zsh-autosuggestions` does its one-shot bind pass → wraps `accept-line`, `accept-and-hold`, etc.
2. Later in `.zshrc`: `eval "$(forge zsh plugin)"` → Forge's `bindings.zsh` runs → defines `forge-accept-line`, binds `^M` and `^J` to it.

After step 2, pressing Enter routes to an **unwrapped** widget. Autosuggestions' CLEAR hook never runs, `POSTDISPLAY` is never cleared visually, and the ghost suggestion hangs around.

Note: `forge-accept-line`'s non-`:command` path calls `zle accept-line`, which *is* wrapped — so `POSTDISPLAY` is cleared in zsh's *internal* state. But by then Forge has already emitted OSC 133 markers and done its own redisplay, so the terminal has painted the ghost text and doesn't repaint without it.

## Fix

Append `forge-accept-line` to `ZSH_AUTOSUGGEST_CLEAR_WIDGETS` at the bottom of `shell-plugin/lib/bindings.zsh` — right after the widget is registered and bound — and re-run `_zsh_autosuggest_bind_widgets` so the wrapper is installed.

```zsh
if typeset -p ZSH_AUTOSUGGEST_CLEAR_WIDGETS >/dev/null 2>&1; then
    if [[ ${ZSH_AUTOSUGGEST_CLEAR_WIDGETS[(Ie)forge-accept-line]} -eq 0 ]]; then
        ZSH_AUTOSUGGEST_CLEAR_WIDGETS+=(forge-accept-line)
        if typeset -f _zsh_autosuggest_bind_widgets >/dev/null 2>&1; then
            _zsh_autosuggest_bind_widgets
        fi
    fi
fi
```

Four defensive properties, all verified:

- **Safe no-op** when autosuggestions isn't loaded (`typeset -p` guard on the array).
- **Idempotent** — re-sourcing `bindings.zsh` doesn't duplicate the entry or re-trigger the bind pass.
- **Backward-compatible** with older autosuggestions releases that predate `_zsh_autosuggest_bind_widgets` (the helper check gracefully skips re-binding).
- **No impact** on users who don't use autosuggestions.

## Verification

The repo doesn't have a shell-level test harness, so I wrote a stand-alone zsh verification script that extracts the integration block from `bindings.zsh` and exercises it against stubbed autosuggestions state. It covers:

- happy path: widget appended, `_zsh_autosuggest_bind_widgets` called exactly once
- idempotence: re-sourcing doesn't duplicate or re-fire the bind
- graceful no-op when `ZSH_AUTOSUGGEST_CLEAR_WIDGETS` is unset
- works when `_zsh_autosuggest_bind_widgets` is missing (older autosuggestions)

```
$ zsh /tmp/forge-fix-verify.zsh
PASS: forge-accept-line added to ZSH_AUTOSUGGEST_CLEAR_WIDGETS
PASS: _zsh_autosuggest_bind_widgets was re-invoked exactly once
PASS: re-sourcing does not duplicate the entry (count=1)
PASS: bind_widgets not called again on re-source
PASS: no-op when ZSH_AUTOSUGGEST_CLEAR_WIDGETS is unset
PASS: array updated even when bind_widgets fn missing

ALL TESTS PASS
```

The test also caught a real regression in my first draft (an `&&` chain that propagated failure when `_zsh_autosuggest_bind_widgets` was absent) before I pushed. Happy to add the harness to the repo in a follow-up if that'd be useful.

Manual end-to-end verification on my machine:

1. `brew install forgecode` (2.12.10) + Oh-My-Zsh with `zsh-autosuggestions`.
2. Before the patch: gray suggestion persists after Enter.
3. After applying the patch (via a sourced sidecar file): gray suggestion cleared immediately on Enter, no more overlap with prompt.

## Alternatives considered

- **Register with `ZSH_AUTOSUGGEST_ACCEPT_WIDGETS` too.** Not needed: the right pattern for "Enter was pressed, ghost text must go" is CLEAR. ACCEPT is for widgets that should *commit* the suggestion into the buffer (tab-like behavior). We want clear, not accept.
- **Use `ZSH_AUTOSUGGEST_EXECUTE_WIDGETS`.** Same reasoning — EXECUTE is for "commit and run the suggestion," which isn't what Enter with a partial suggestion should do.
- **Document it as a user-side config.** The user shouldn't have to know about autosuggestions' widget-registration internals to get a working shell; Forge ships a custom `accept-line` and is therefore responsible for coordinating with the widget-wrapping plugins it already lists as required.

## Related

- #2681 — different direction (zsh-vi-mode rebinds widgets and breaks Forge) but the same underlying class of bug: Forge doesn't coordinate with other widget-wrapping plugins. Worth a broader pattern fix eventually; this PR just addresses the autosuggestions leg.

## Notes

Committed with `Co-Authored-By: ForgeCode <noreply@forgecode.dev>` per the `AGENTS.md` guidelines.
