### PR TITLE
fix: skip selector keyboard on windows

### DIFF
--- a/crates/forge_select/src/preview.rs
+++ b/crates/forge_select/src/preview.rs
@@ -227,10 +227,7 @@ impl TerminalGuard {
         enable_raw_mode()?;
         execute!(io::stderr(), EnableMouseCapture, Hide)?;
         let keyboard_enhancement_enabled = enable_keyboard_enhancement()?;
-        Ok(Self {
-            raw_mode_was_enabled,
-            keyboard_enhancement_enabled,
-        })
+        Ok(Self { raw_mode_was_enabled, keyboard_enhancement_enabled })
     }
 }
 

--- a/crates/forge_select/src/preview.rs
+++ b/crates/forge_select/src/preview.rs
@@ -9,8 +9,11 @@ use bstr::ByteSlice;
 use crossterm::cursor::{Hide, MoveTo, MoveToColumn, MoveUp, Show};
 use crossterm::event::{
     self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyModifiers,
-    KeyboardEnhancementFlags, MouseEventKind, PopKeyboardEnhancementFlags,
-    PushKeyboardEnhancementFlags,
+    MouseEventKind,
+};
+#[cfg(not(windows))]
+use crossterm::event::{
+    KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 use crossterm::style::{
     Attribute, Color, Print, ResetColor, SetAttribute, SetBackgroundColor, SetForegroundColor,
@@ -215,30 +218,43 @@ fn clear_rendered_viewport(
 
 struct TerminalGuard {
     raw_mode_was_enabled: bool,
+    keyboard_enhancement_enabled: bool,
 }
 
 impl TerminalGuard {
     fn enter() -> anyhow::Result<Self> {
         let raw_mode_was_enabled = terminal::is_raw_mode_enabled()?;
         enable_raw_mode()?;
-        execute!(
-            io::stderr(),
-            EnableMouseCapture,
-            PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES),
-            Hide
-        )?;
-        Ok(Self { raw_mode_was_enabled })
+        execute!(io::stderr(), EnableMouseCapture, Hide)?;
+        let keyboard_enhancement_enabled = enable_keyboard_enhancement()?;
+        Ok(Self {
+            raw_mode_was_enabled,
+            keyboard_enhancement_enabled,
+        })
     }
+}
+
+#[cfg(not(windows))]
+fn enable_keyboard_enhancement() -> anyhow::Result<bool> {
+    execute!(
+        io::stderr(),
+        PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+    )?;
+    Ok(true)
+}
+
+#[cfg(windows)]
+fn enable_keyboard_enhancement() -> anyhow::Result<bool> {
+    Ok(false)
 }
 
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
-        let _ = execute!(
-            io::stderr(),
-            Show,
-            PopKeyboardEnhancementFlags,
-            DisableMouseCapture
-        );
+        let _ = execute!(io::stderr(), Show);
+        if self.keyboard_enhancement_enabled {
+            let _ = execute!(io::stderr(), PopKeyboardEnhancementFlags);
+        }
+        let _ = execute!(io::stderr(), DisableMouseCapture);
         if !self.raw_mode_was_enabled {
             let _ = disable_raw_mode();
         }


### PR DESCRIPTION
## Summary
Fix the Windows selector startup failure by skipping crossterm keyboard progressive enhancement on Windows while preserving normal selector input handling.

## Context
Fixes #3285.

The selector currently pushes `KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES` during terminal setup. On Windows, crossterm can route that command through the legacy Windows API path for stderr, where keyboard progressive enhancement is unsupported and fails before the selector can render.


## Changes
- Gate keyboard progressive enhancement imports and setup to non-Windows platforms.
- Track whether keyboard enhancement was enabled before attempting to pop it during teardown.
- Preserve raw mode, mouse capture, cursor hide/show, and the existing selector event loop behavior.

### Key Implementation Details
Windows now returns `false` from the keyboard enhancement setup helper, so teardown skips `PopKeyboardEnhancementFlags`. Non-Windows platforms continue to use `PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)` as before.

## Use Cases
- Windows users can open nucleo-backed list selectors without hitting crossterm's unsupported progressive keyboard enhancement error.
- Basic selector interactions continue to work: typing to filter, arrow navigation, enter/escape, tab multi-select, page up/down, and mouse wheel scrolling.

## Testing
```bash
cargo check -p forge_select
```

## Links
- Related issues: #3285
