### PR TITLE
fix: update Fire Pass Kimi K2.6 Turbo router

### DIFF
--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -3310,9 +3310,9 @@
         "input_modalities": ["text", "image"]
       },
       {
-        "id": "accounts/fireworks/routers/kimi-k2p6",
-        "name": "Kimi K2.6 (Firepass)",
-        "description": "Kimi K2.6 model",
+        "id": "accounts/fireworks/routers/kimi-k2p6-turbo",
+        "name": "Kimi K2.6 Turbo (Fire Pass)",
+        "description": "Kimi K2.6 Turbo model",
         "context_length": 262144,
         "tools_supported": true,
         "supports_parallel_tool_calls": true,


### PR DESCRIPTION
Fireworks updated Fire Pass to v2, and the current Fire Pass plan only supports one router model:

`accounts/fireworks/routers/kimi-k2p6-turbo`

This updates Forge's Fireworks provider config from `accounts/fireworks/routers/kimi-k2p6` to the new v2 router model.

Docs: https://docs.fireworks.ai/firepass

I also tried configuring this through Forge's custom model/provider flow, but Fire Pass API keys are not authorized for the `/v1/models` query. Because Forge validates custom provider models through that endpoint, the built-in provider list needs this direct model ID update.