### PR TITLE
fix: skip vscode auto-install on windows

### DIFF
--- a/crates/forge_main/src/vscode.rs
+++ b/crates/forge_main/src/vscode.rs
@@ -49,9 +49,14 @@ pub fn install_extension() -> Result<bool, std::io::Error> {
 /// Returns true if we should install the extension
 ///
 /// This will return true only when:
+/// - Not running on native Windows
 /// - Running in VS Code terminal
 /// - Extension is not installed
 pub fn should_install_extension() -> bool {
+    if cfg!(windows) {
+        return false;
+    }
+
     is_vscode_terminal() && !is_extension_installed()
 }
 


### PR DESCRIPTION
## Summary
Fix native Windows prompt submissions opening extra VS Code windows by skipping automatic VS Code extension checks and installs on Windows.

## Context
Fixes #3189.

Forge currently attempts to auto-install the VS Code extension from the prompt flow when it detects a VS Code terminal. On native Windows, the reporter confirmed that both `code --list-extensions` and `code --install-extension ForgeCode.forge-vscode --force` open a new VS Code window, which causes duplicate windows to appear on every prompt submission.

## Changes
- Short-circuit `should_install_extension()` on Windows before checking whether Forge is running inside VS Code.
- Prevent automatic prompt-time execution of `code --list-extensions` on Windows.
- Prevent automatic prompt-time execution of `code --install-extension ForgeCode.forge-vscode --force` on Windows.
- Keep explicit/manual VS Code extension installation behavior unchanged.

### Key Implementation Details
The guard lives in the existing VS Code auto-install decision function, so the rest of the prompt flow remains unchanged. Non-Windows behavior continues to use the existing VS Code terminal detection and extension installation check.

## Testing
```bash
cargo test -p forge_main vscode
```

Result: 8 passed, 0 failed.

## Links
- Related issue: #3189
