### PR TITLE
fix: add fireworks-ai-firepass provider with kimi-k2p6-turbo model

### DIFF
--- a/crates/forge_app/src/dto/openai/transformers/pipeline.rs
+++ b/crates/forge_app/src/dto/openai/transformers/pipeline.rs
@@ -79,6 +79,7 @@ impl Transformer for ProviderPipeline<'_> {
 
         let reasoning_content = ReasoningContent.when(move |request: &Request| {
             provider.id == ProviderId::FIREWORKS_AI
+                || provider.id == ProviderId::FIREWORKS_AI_FIREPASS
                 || is_deepseek_compatible(provider, request)
                 || when_model("kimi")(request)
         });
@@ -103,6 +104,7 @@ impl Transformer for ProviderPipeline<'_> {
             .pipe(EnforceStrictResponseFormatSchema)
             .when(move |_| {
                 provider.id == ProviderId::FIREWORKS_AI
+                    || provider.id == ProviderId::FIREWORKS_AI_FIREPASS
                     || provider.id == ProviderId::OPENCODE_ZEN
                     || provider.id == ProviderId::OPENCODE_GO
                     || provider.id == ProviderId::XAI

--- a/crates/forge_domain/src/provider.rs
+++ b/crates/forge_domain/src/provider.rs
@@ -72,7 +72,8 @@ impl ProviderId {
     pub const OPENCODE_ZEN: ProviderId = ProviderId(Cow::Borrowed("opencode_zen"));
     pub const OPENCODE_GO: ProviderId = ProviderId(Cow::Borrowed("opencode_go"));
     pub const FIREWORKS_AI: ProviderId = ProviderId(Cow::Borrowed("fireworks-ai"));
-    pub const FIREWORKS_AI_FIREPASS: ProviderId = ProviderId(Cow::Borrowed("fireworks-ai-firepass"));
+    pub const FIREWORKS_AI_FIREPASS: ProviderId =
+        ProviderId(Cow::Borrowed("fireworks-ai-firepass"));
     pub const NOVITA: ProviderId = ProviderId(Cow::Borrowed("novita"));
     pub const VIVGRID: ProviderId = ProviderId(Cow::Borrowed("vivgrid"));
     pub const GOOGLE_AI_STUDIO: ProviderId = ProviderId(Cow::Borrowed("google_ai_studio"));

--- a/crates/forge_domain/src/provider.rs
+++ b/crates/forge_domain/src/provider.rs
@@ -72,6 +72,7 @@ impl ProviderId {
     pub const OPENCODE_ZEN: ProviderId = ProviderId(Cow::Borrowed("opencode_zen"));
     pub const OPENCODE_GO: ProviderId = ProviderId(Cow::Borrowed("opencode_go"));
     pub const FIREWORKS_AI: ProviderId = ProviderId(Cow::Borrowed("fireworks-ai"));
+    pub const FIREWORKS_AI_FIREPASS: ProviderId = ProviderId(Cow::Borrowed("fireworks-ai-firepass"));
     pub const NOVITA: ProviderId = ProviderId(Cow::Borrowed("novita"));
     pub const VIVGRID: ProviderId = ProviderId(Cow::Borrowed("vivgrid"));
     pub const GOOGLE_AI_STUDIO: ProviderId = ProviderId(Cow::Borrowed("google_ai_studio"));
@@ -111,6 +112,7 @@ impl ProviderId {
             ProviderId::OPENCODE_ZEN,
             ProviderId::OPENCODE_GO,
             ProviderId::FIREWORKS_AI,
+            ProviderId::FIREWORKS_AI_FIREPASS,
             ProviderId::NOVITA,
             ProviderId::VIVGRID,
             ProviderId::GOOGLE_AI_STUDIO,
@@ -144,6 +146,7 @@ impl ProviderId {
             "opencode_zen" => "OpenCode Zen".to_string(),
             "opencode_go" => "OpenCode Go".to_string(),
             "fireworks-ai" => "FireworksAI".to_string(),
+            "fireworks-ai-firepass" => "FireworksAIFirepass".to_string(),
             "novita" => "Novita".to_string(),
             "vivgrid" => "Vivgrid".to_string(),
             "google_ai_studio" => "GoogleAIStudio".to_string(),
@@ -195,6 +198,7 @@ impl std::str::FromStr for ProviderId {
             "codex" => ProviderId::CODEX,
             "opencode_go" => ProviderId::OPENCODE_GO,
             "fireworks-ai" => ProviderId::FIREWORKS_AI,
+            "fireworks-ai-firepass" => ProviderId::FIREWORKS_AI_FIREPASS,
             "novita" => ProviderId::NOVITA,
             "vertex_ai_anthropic" => ProviderId::VERTEX_AI_ANTHROPIC,
             "bedrock" => ProviderId::BEDROCK,
@@ -792,6 +796,27 @@ mod tests {
         let actual = fixture.url.clone();
         let expected = Url::parse("https://us-central1-aiplatform.googleapis.com/v1/projects/test_project/locations/us-central1/endpoints/openapi/chat/completions").unwrap();
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_fireworks_ai_firepass_from_str() {
+        let actual = ProviderId::from_str("fireworks-ai-firepass").unwrap();
+        let expected = ProviderId::FIREWORKS_AI_FIREPASS;
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_fireworks_ai_firepass_display_name() {
+        assert_eq!(
+            ProviderId::FIREWORKS_AI_FIREPASS.to_string(),
+            "FireworksAIFirepass"
+        );
+    }
+
+    #[test]
+    fn test_fireworks_ai_firepass_in_built_in_providers() {
+        let built_in = ProviderId::built_in_providers();
+        assert!(built_in.contains(&ProviderId::FIREWORKS_AI_FIREPASS));
     }
 
     #[test]

--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -3442,7 +3442,7 @@
   },
   {
     "id": "fireworks-ai-firepass",
-    "api_key_vars": "FIREWORKS_AI_API_KEY",
+    "api_key_vars": "FIREWORKS_AI_FIREPASS_API_KEY",
     "url_param_vars": [],
     "response_type": "OpenAI",
     "url": "https://api.fireworks.ai/inference/v1/chat/completions",

--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -3300,26 +3300,6 @@
     "auth_methods": ["api_key"],
     "models": [
       {
-        "id": "accounts/fireworks/routers/kimi-k2p5-turbo",
-        "name": "Kimi K2.5 Turbo (Firepass) ",
-        "description": "Kimi K2.5 Turbo model",
-        "context_length": 256000,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text", "image"]
-      },
-      {
-        "id": "accounts/fireworks/routers/kimi-k2p6-turbo",
-        "name": "Kimi K2.6 Turbo (Fire Pass)",
-        "description": "Kimi K2.6 Turbo model",
-        "context_length": 262144,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text", "image"]
-      },
-      {
         "id": "accounts/fireworks/models/kimi-k2p5",
         "name": "Kimi K2.5",
         "description": "Kimi K2.5 model",
@@ -3457,6 +3437,26 @@
         "supports_parallel_tool_calls": true,
         "supports_reasoning": true,
         "input_modalities": ["text"]
+      }
+    ]
+  },
+  {
+    "id": "fireworks-ai-firepass",
+    "api_key_vars": "FIREWORKS_AI_API_KEY",
+    "url_param_vars": [],
+    "response_type": "OpenAI",
+    "url": "https://api.fireworks.ai/inference/v1/chat/completions",
+    "auth_methods": ["api_key"],
+    "models": [
+      {
+        "id": "accounts/fireworks/routers/kimi-k2p6-turbo",
+        "name": "Kimi K2.6 Turbo (firepass)",
+        "description": "Kimi K2.6 Turbo model",
+        "context_length": 262144,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
       }
     ]
   },


### PR DESCRIPTION
## Summary

Add a dedicated `fireworks-ai-firepass` provider to separate Firepass router models from the standard `fireworks-ai` provider. This replaces the previous approach of embedding firepass models directly within the fireworks-ai provider.

## Changes

### New Provider: `fireworks-ai-firepass`
- Added `FIREWORKS_AI_FIREPASS` `ProviderId` constant (`"fireworks-ai-firepass"`) with display name `"FireworksAIFirepass"`
- Registered in `built_in_providers()` list and `FromStr` mappings
- New provider entry in `provider.json` sharing the same API URL (`https://api.fireworks.ai/inference/v1/chat/completions`) and `FIREWORKS_AI_API_KEY` env var as the existing `fireworks-ai` provider

### New Model: Kimi K2.6 Turbo (firepass)
- Model ID: `accounts/fireworks/routers/kimi-k2p6-turbo`
- Display name: **Kimi K2.6 Turbo (firepass)**
- 262K context length
- Supports: tool use, parallel tool calls, reasoning, text + image input modalities
- Based on the existing k2p6-turbo configuration

### Removed Deprecated Models
- Removed `kimi-k2p5-turbo` (Kimi K2.5 Turbo Firepass) from the `fireworks-ai` provider
- Removed `kimi-k2p6-turbo` (Kimi K2.6 Turbo Fire Pass) from the `fireworks-ai` provider

### Pipeline Transformers
- Extended `ReasoningContent` transformer to apply to `FIREWORKS_AI_FIREPASS`
- Extended `EnforceStrictToolSchema` + `EnforceStrictResponseFormatSchema` pipeline to apply to `FIREWORKS_AI_FIREPASS`

### Tests
- Added 3 unit tests: `from_str`, `display_name`, `in_built_in_providers`

## Files Changed

| File | Change |
|------|--------|
| `crates/forge_domain/src/provider.rs` | New provider constant, mappings, and tests (+21) |
| `crates/forge_repo/src/provider/provider.json` | Removed firepass models from fireworks-ai, added new provider entry (+20/-20) |
| `crates/forge_app/src/dto/openai/transformers/pipeline.rs` | Extended transformers to new provider (+2) |

## Verification

- `cargo check` passes
- All 590 tests pass in `forge_domain` + `forge_app`
- All 317 tests pass in `forge_repo`