### PR TITLE
fix(kv_storage): handle cache clearing with regular files

### DIFF
--- a/crates/forge_infra/src/kv_storage.rs
+++ b/crates/forge_infra/src/kv_storage.rs
@@ -140,20 +140,10 @@ impl forge_app::KVStore for CacacheStorage {
         // fails with ENOTDIR when regular files (e.g. .mcp.json) are present.
         tokio::fs::remove_dir_all(&self.cache_dir)
             .await
-            .with_context(|| {
-                format!(
-                    "Failed to clear cache at {}",
-                    self.cache_dir.display()
-                )
-            })?;
+            .with_context(|| format!("Failed to clear cache at {}", self.cache_dir.display()))?;
         tokio::fs::create_dir_all(&self.cache_dir)
             .await
-            .with_context(|| {
-                format!(
-                    "Failed to recreate cache at {}",
-                    self.cache_dir.display()
-                )
-            })?;
+            .with_context(|| format!("Failed to recreate cache at {}", self.cache_dir.display()))?;
         Ok(())
     }
 }

--- a/crates/forge_infra/src/kv_storage.rs
+++ b/crates/forge_infra/src/kv_storage.rs
@@ -135,9 +135,25 @@ impl forge_app::KVStore for CacacheStorage {
         if !self.cache_dir.exists() {
             return Ok(());
         }
-        cacache::clear(&self.cache_dir)
+        // Use remove_dir_all + create_dir_all instead of cacache::clear because
+        // cacache::clear calls remove_dir_all on every directory entry, which
+        // fails with ENOTDIR when regular files (e.g. .mcp.json) are present.
+        tokio::fs::remove_dir_all(&self.cache_dir)
             .await
-            .context("Failed to clear cache")?;
+            .with_context(|| {
+                format!(
+                    "Failed to clear cache at {}",
+                    self.cache_dir.display()
+                )
+            })?;
+        tokio::fs::create_dir_all(&self.cache_dir)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to recreate cache at {}",
+                    self.cache_dir.display()
+                )
+            })?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
Fix cache clearing to handle directories that contain regular files (e.g. `.mcp.json`) alongside cacache-managed entries.

## Context
`cacache::clear` internally calls `remove_dir_all` on every entry within the cache directory. When regular files (such as `.mcp.json`) are present alongside cacache-managed subdirectories, this fails with `ENOTDIR` because it tries to treat those files as directories.

The fix replaces `cacache::clear` with a simpler and more robust approach: remove the entire cache directory and immediately recreate it.

## Changes
- Replaced `cacache::clear` with `tokio::fs::remove_dir_all` + `tokio::fs::create_dir_all` in `CacacheStorage::clear`
- Improved error messages to include the cache directory path for easier debugging

### Key Implementation Details
`cacache::clear` iterates over entries in the cache dir and calls `remove_dir_all` on each one, which fails when it encounters plain files. Removing the whole directory and recreating it avoids this entirely and is equivalent in effect — the cache is fully cleared and ready to accept new entries.

## Testing
```bash
# Place a regular file inside the cache directory, then trigger a clear
cargo test -p forge_infra
```

## Links
- No related issues
