### PR TITLE
fix(openai): replay reasoning_content for Xiaomi MiMo tool calls

### DIFF
--- a/crates/forge_app/src/dto/openai/transformers/pipeline.rs
+++ b/crates/forge_app/src/dto/openai/transformers/pipeline.rs
@@ -82,10 +82,12 @@ impl Transformer for ProviderPipeline<'_> {
                 || provider.id == ProviderId::FIREWORKS_AI_FIREPASS
                 || is_deepseek_compatible(provider, request)
                 || when_model("kimi")(request)
+                || is_xiaomi_mimo_provider(provider)
         });
 
-        let default_reasoning_content = DefaultReasoningContent
-            .when(move |request: &Request| is_deepseek_compatible(provider, request));
+        let default_reasoning_content = DefaultReasoningContent.when(move |request: &Request| {
+            is_deepseek_compatible(provider, request) || is_xiaomi_mimo_provider(provider)
+        });
 
         let cerebras_compat = MakeCerebrasCompat.when(move |_| provider.id == ProviderId::CEREBRAS);
 
@@ -156,6 +158,12 @@ fn is_deepseek_compatible(provider: &Provider<Url>, request: &Request) -> bool {
             .is_some_and(|m| m.as_str().contains("deepseek"));
     }
     false
+}
+
+/// Checks if provider is Xiaomi MiMo, which requires reasoning to be replayed
+/// as a flat reasoning_content field in follow-up requests.
+fn is_xiaomi_mimo_provider(provider: &Provider<Url>) -> bool {
+    provider.id == ProviderId::XIAOMI_MIMO
 }
 
 /// Checks if the request model is a gemini-3 model (which supports thought
@@ -380,6 +388,22 @@ mod tests {
             custom_headers: None,
             models: Some(ModelSource::Url(
                 Url::parse("https://api.deepseek.com/models").unwrap(),
+            )),
+        }
+    }
+
+    fn xiaomi_mimo(key: &str) -> Provider<Url> {
+        Provider {
+            id: ProviderId::XIAOMI_MIMO,
+            provider_type: Default::default(),
+            response: Some(ProviderResponse::OpenAI),
+            url: Url::parse("https://token-plan-sgp.xiaomimimo.com/v1/chat/completions").unwrap(),
+            auth_methods: vec![forge_domain::AuthMethod::ApiKey],
+            url_params: vec![],
+            credential: make_credential(ProviderId::XIAOMI_MIMO, key),
+            custom_headers: None,
+            models: Some(ModelSource::Url(
+                Url::parse("https://token-plan-sgp.xiaomimimo.com/v1/models").unwrap(),
             )),
         }
     }
@@ -1212,6 +1236,61 @@ mod tests {
         // DeepSeek transforms; reasoning_details should remain as-is.
         assert_eq!(message.reasoning_content, None);
         assert!(message.reasoning_details.is_some());
+    }
+
+    #[test]
+    fn test_xiaomi_mimo_provider_converts_reasoning_details_to_reasoning_content() {
+        let provider = xiaomi_mimo("xiaomi-mimo");
+        let fixture = Request::default().messages(vec![crate::dto::openai::Message {
+            role: crate::dto::openai::Role::Assistant,
+            content: Some(crate::dto::openai::MessageContent::Text("test".to_string())),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+            reasoning_details: Some(vec![crate::dto::openai::ReasoningDetail {
+                r#type: "reasoning.text".to_string(),
+                text: Some("thinking...".to_string()),
+                signature: None,
+                data: None,
+                id: None,
+                format: None,
+                index: None,
+            }]),
+            reasoning_text: None,
+            reasoning_opaque: None,
+            reasoning_content: None,
+            extra_content: None,
+        }]);
+
+        let mut pipeline = ProviderPipeline::new(&provider, false);
+        let actual = pipeline.transform(fixture);
+
+        let message = actual.messages.unwrap().into_iter().next().unwrap();
+        assert_eq!(message.reasoning_content, Some("thinking...".to_string()));
+        assert!(message.reasoning_details.is_none());
+    }
+
+    #[test]
+    fn test_xiaomi_mimo_provider_falls_back_to_empty_reasoning_content_when_none() {
+        let provider = xiaomi_mimo("xiaomi-mimo");
+        let fixture = Request::default().messages(vec![crate::dto::openai::Message {
+            role: crate::dto::openai::Role::Assistant,
+            content: Some(crate::dto::openai::MessageContent::Text("test".to_string())),
+            name: None,
+            tool_call_id: None,
+            tool_calls: None,
+            reasoning_details: None,
+            reasoning_text: None,
+            reasoning_opaque: None,
+            reasoning_content: None,
+            extra_content: None,
+        }]);
+
+        let mut pipeline = ProviderPipeline::new(&provider, false);
+        let actual = pipeline.transform(fixture);
+
+        let message = actual.messages.unwrap().into_iter().next().unwrap();
+        assert_eq!(message.reasoning_content, Some(String::new()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Xiaomi MiMo API requires `reasoning_content` in follow-up requests when tool calls exist in conversation histo
ry. Forge's pipeline already handles this for DeepSeek, Fireworks, and Kimi via the `ReasoningContent` + `DefaultReasoningContent` transformers, but Xiaomi MiMo was left out, causing tool-based conversations to fail after the first tool call.

## Fix

Three changes in `crates/forge_app/src/dto/openai/transformers/pipeline.rs`:

1. **`ReasoningContent` guard** — added `is_xiaomi_mimo_provider(provider)` so that `reasoning_details` are converted to `reasoning_content` for MiMo, matching DeepSeek/Fireworks/Kimi behavior.

2. **`DefaultReasoningContent` guard** — added the same check so that assistant messages without reasoning still get an empty `reasoning_content` field, which MiMo requires when tool calls are present.

3. **New helper** — extracted `is_xiaomi_mimo_provider()` following the existing `is_deepseek_provider()` / `is_zai_provider()` pattern.

## Testing

Two new tests added (mirroring existing DeepSeek tests):
- `test_xiaomi_mimo_provider_converts_reasoning_details_to_reasoning_content` — `reasoning_details` → `reasoning_content` conversion
- `test_xiaomi_mimo_provider_falls_back_to_empty_reasoning_content_when_none` — verifies empty fallback when no reasoning is present

Full test suite: **702 passed, 0 failed**. Clippy and fmt clean.

## Related

- Fixes[ #[3347]](https://github.com/tailcallhq/forgecode/issues/3347)