### PR TITLE
Add retry command parser coverage

### DIFF
--- a/crates/forge_main/src/model.rs
+++ b/crates/forge_main/src/model.rs
@@ -1097,6 +1097,34 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_retry_command() {
+        let fixture = ForgeCommandManager::default();
+        let actual = fixture.parse("/retry").unwrap();
+
+        assert_eq!(actual, AppCommand::Retry);
+    }
+
+    #[test]
+    fn test_parse_retry_alias() {
+        let fixture = ForgeCommandManager::default();
+        let actual = fixture.parse("/r").unwrap();
+
+        assert_eq!(actual, AppCommand::Retry);
+    }
+
+    #[test]
+    fn test_retry_command_in_default_commands() {
+        let manager = ForgeCommandManager::default();
+        let commands = manager.list();
+        let contains_retry = commands.iter().any(|cmd| cmd.name == "retry");
+
+        assert!(
+            contains_retry,
+            "Retry command should be in default commands"
+        );
+    }
+
+    #[test]
     fn test_sanitize_agent_id_basic() {
         // Test basic sanitization
         let fixture = "test-agent";


### PR DESCRIPTION
## Summary
- add regression coverage that interactive `/retry` parses to `AppCommand::Retry`
- add coverage for the `/r` alias
- assert retry remains listed in the default interactive commands

The current runtime path already retries by calling `UI::on_message(None)`, matching the maintainer note on #389. This PR locks the exposed command surface down so that behavior stays reachable from the chat prompt.

## Verification
- `cargo test -p forge_main retry`
- `git diff --check`

Note: `cargo fmt --check` currently reports an unrelated existing formatting diff in `crates/forge_main/src/info.rs`, so I did not include that file in this PR.

/claim #389