### PR TITLE
feat: retry the last user event

### DIFF
--- a/crates/forge_api/src/api.rs
+++ b/crates/forge_api/src/api.rs
@@ -46,6 +46,13 @@ pub trait API: Sync + Send {
     /// Executes a chat request and returns a stream of responses
     async fn chat(&self, chat: ChatRequest) -> Result<MpscStream<Result<ChatResponse>>>;
 
+    /// Retries the most recent retryable user event in an existing
+    /// conversation.
+    async fn retry(
+        &self,
+        conversation_id: &ConversationId,
+    ) -> Result<MpscStream<Result<ChatResponse>>>;
+
     /// Commits changes with an AI-generated commit message
     async fn commit(
         &self,

--- a/crates/forge_api/src/forge_api.rs
+++ b/crates/forge_api/src/forge_api.rs
@@ -147,6 +147,18 @@ impl<
         self.app().chat(agent_id, chat).await
     }
 
+    async fn retry(
+        &self,
+        conversation_id: &ConversationId,
+    ) -> anyhow::Result<MpscStream<Result<ChatResponse, anyhow::Error>>> {
+        let agent_id = self
+            .services
+            .get_active_agent_id()
+            .await?
+            .unwrap_or_default();
+        self.app().retry(agent_id, conversation_id).await
+    }
+
     async fn upsert_conversation(&self, conversation: Conversation) -> anyhow::Result<()> {
         self.services.upsert_conversation(conversation).await
     }

--- a/crates/forge_app/src/app.rs
+++ b/crates/forge_app/src/app.rs
@@ -208,6 +208,30 @@ impl<S: Services + EnvironmentInfra<Config = forge_config::ForgeConfig>> ForgeAp
         Ok(stream)
     }
 
+    /// Retries the most recent retryable user event in an existing
+    /// conversation.
+    pub async fn retry(
+        &self,
+        agent_id: AgentId,
+        conversation_id: &ConversationId,
+    ) -> Result<MpscStream<Result<ChatResponse, anyhow::Error>>> {
+        let conversation = self
+            .services
+            .find_conversation(conversation_id)
+            .await?
+            .ok_or_else(|| forge_domain::Error::ConversationNotFound(*conversation_id))?;
+
+        let event = conversation.last_retryable_event().ok_or_else(|| {
+            anyhow::anyhow!(
+                "No retryable user event found in conversation {}",
+                conversation_id.into_string()
+            )
+        })?;
+
+        self.chat(agent_id, ChatRequest::new(event, *conversation_id))
+            .await
+    }
+
     /// Compacts the context of the main agent for the given conversation and
     /// persists it. Returns metrics about the compaction (original vs.
     /// compacted tokens and messages).

--- a/crates/forge_domain/src/conversation.rs
+++ b/crates/forge_domain/src/conversation.rs
@@ -6,7 +6,7 @@ use derive_setters::Setters;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{Context, Error, Metrics, Result, TokenCount};
+use crate::{Context, Error, Event, Metrics, Result, TokenCount};
 
 #[derive(Debug, Default, Display, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 #[serde(transparent)]
@@ -113,6 +113,24 @@ impl Conversation {
             .unwrap_or_default()
     }
 
+    /// Returns the most recent retryable user event recorded in the
+    /// conversation.
+    ///
+    /// Retry uses the raw event captured before prompt-template rendering, so
+    /// synthetic user messages such as todo reminders or attachment expansions
+    /// are skipped automatically because they do not preserve `raw_content`.
+    pub fn last_retryable_event(&self) -> Option<Event> {
+        self.context
+            .as_ref()
+            .and_then(|ctx| {
+                ctx.messages
+                    .iter()
+                    .rev()
+                    .find_map(|msg| msg.as_value().cloned())
+            })
+            .map(Event::new)
+    }
+
     /// Returns the total token usage across all messages in the conversation.
     ///
     /// This is a convenience method that aggregates usage from the context,
@@ -207,7 +225,9 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
-    use crate::{Context, ContextMessage, ToolOutput, ToolResult, ToolValue};
+    use crate::{
+        Context, ContextMessage, EventValue, Role, TextMessage, ToolOutput, ToolResult, ToolValue,
+    };
 
     #[test]
     fn test_related_conversation_ids_empty() {
@@ -354,5 +374,39 @@ mod tests {
         let expected = Some(0.05);
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_last_retryable_event_returns_latest_raw_user_event() {
+        let context = Context::default()
+            .add_message(
+                TextMessage::new(Role::User, "Rendered first")
+                    .raw_content(EventValue::text("First task")),
+            )
+            .add_message(ContextMessage::assistant("Done", None, None, None))
+            .add_message(
+                TextMessage::new(Role::User, "Rendered second")
+                    .raw_content(EventValue::text("Second task")),
+            );
+
+        let conversation = Conversation::generate().context(context);
+        let actual = conversation.last_retryable_event().unwrap();
+
+        assert_eq!(actual.value, Some(EventValue::text("Second task")));
+    }
+
+    #[test]
+    fn test_last_retryable_event_skips_synthetic_user_messages() {
+        let context = Context::default()
+            .add_message(
+                TextMessage::new(Role::User, "Rendered task")
+                    .raw_content(EventValue::text("Retry me")),
+            )
+            .add_message(TextMessage::new(Role::User, "Attachment expansion").droppable(true));
+
+        let conversation = Conversation::generate().context(context);
+        let actual = conversation.last_retryable_event().unwrap();
+
+        assert_eq!(actual.value, Some(EventValue::text("Retry me")));
     }
 }

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -905,8 +905,7 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                 let original_id = self.state.conversation_id;
                 self.state.conversation_id = Some(id);
 
-                self.spinner.start(None)?;
-                self.on_message(None).await?;
+                self.on_retry(id).await?;
 
                 self.state.conversation_id = original_id;
             }
@@ -2191,8 +2190,14 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                 return self.handle_provider_logout(None).await;
             }
             AppCommand::Retry => {
-                self.spinner.start(None)?;
-                self.on_message(None).await?;
+                let conversation_id = self
+                    .state
+                    .conversation_id
+                    .or(self.cli.conversation_id)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("No conversation to retry. Start a conversation first.")
+                    })?;
+                self.on_retry(conversation_id).await?;
             }
             AppCommand::Index => {
                 let working_dir = self.state.cwd.clone();
@@ -3893,6 +3898,37 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
         let chat = ChatRequest::new(event, conversation_id);
 
         self.on_chat(chat).await
+    }
+
+    async fn on_retry(&mut self, conversation_id: ConversationId) -> Result<()> {
+        self.writeln_title(TitleFormat::debug(format!(
+            "Retry {}",
+            conversation_id.into_string()
+        )))?;
+        self.spinner.start(None)?;
+
+        let mut stream = self.api.retry(&conversation_id).await?;
+
+        // Always use streaming content writer
+        let mut writer = StreamingWriter::new(self.spinner.clone(), self.api.clone());
+
+        while let Some(message) = stream.next().await {
+            match message {
+                Ok(message) => self.handle_chat_response(message, &mut writer).await?,
+                Err(err) => {
+                    writer.finish()?;
+                    self.spinner.stop(None)?;
+                    self.spinner.reset();
+                    return Err(err);
+                }
+            }
+        }
+
+        writer.finish()?;
+        self.spinner.stop(None)?;
+        self.spinner.reset();
+
+        Ok(())
     }
 
     async fn on_chat(&mut self, chat: ChatRequest) -> Result<()> {


### PR DESCRIPTION
## Summary
- add a first-class `API::retry(conversation_id)` path instead of routing `/retry` through an empty follow-up message
- rebuild retry requests from the last saved raw user event in conversation history, skipping synthetic user messages that do not preserve raw content
- wire both retry entry points in `forge_main` to the new API method and add focused regression tests for retry event extraction

## Why
The current interactive retry flow is reachable, but it retries by sending an empty follow-up into the conversation. This PR keeps `/retry` tied to the last actual user event, which is a closer semantic match for a real retry and avoids depending on a synthetic empty message.

## Verification
- `cargo test -p forge_domain test_last_retryable_event`
- `cargo test -p forge_main retry`
- `cargo check -p forge_api -p forge_main`
- `git diff --check`

/claim #389