### PR TITLE
Revert "chore(deps): update rust crate reedline to v0.48.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3442,7 +3442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.17.0",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -6656,9 +6656,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.48.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201e8e0160cbe7bb5eb2caccf281e178e77fac95115ab31a2c29edc5593603c8"
+checksum = "2066729dce9fecd28d1c6850a159ee68719130f149b22467c362353e16994e90"
 dependencies = [
  "chrono",
  "crossterm 0.29.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ posthog-rs = "0.7.0"
 pretty_assertions = "1.4.1"
 proc-macro2 = "1.0"
 quote = "1.0"
-reedline = "=0.48.0"
+reedline = "=0.47.0"
 rustyline = "18.0.0"
 regex = "1.12.3"
 reqwest = { version = "0.12.23", features = [


### PR DESCRIPTION
Reverts tailcallhq/forgecode#3406