### PR TITLE
feat(provider): add MiniMax M3 model and prune deprecated M2.x variants

### DIFF
--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -2507,6 +2507,16 @@
     "url": "https://{{#if HOSTNAME}}{{HOSTNAME}}{{else}}api.minimax.io{{/if}}/anthropic/v1/messages",
     "models": [
       {
+        "id": "MiniMax-M3",
+        "name": "MiniMax M3",
+        "description": "Latest generation MiniMax model with enhanced reasoning, function calling, and extended context",
+        "context_length": 1048576,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
         "id": "MiniMax-M2.7",
         "name": "MiniMax M2.7",
         "description": "Peak performance model optimized for code generation and refactoring with advanced reasoning",
@@ -2520,56 +2530,6 @@
         "id": "MiniMax-M2.7-highspeed",
         "name": "MiniMax M2.7 Highspeed",
         "description": "Same performance as M2.7 with significantly faster inference (~100 tps)",
-        "context_length": 204800,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "MiniMax-M2.5",
-        "name": "MiniMax M2.5",
-        "description": "Peak performance model optimized for code generation and refactoring with advanced reasoning",
-        "context_length": 204800,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "MiniMax-M2.5-highspeed",
-        "name": "MiniMax M2.5 Highspeed",
-        "description": "Same performance as M2.5 with significantly faster inference (~100 tps)",
-        "context_length": 204800,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "MiniMax-M2.1",
-        "name": "MiniMax M2.1",
-        "description": "230B total parameters with 10B activated per inference, optimized for code generation and refactoring",
-        "context_length": 204800,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "MiniMax-M2.1-highspeed",
-        "name": "MiniMax M2.1 Highspeed",
-        "description": "Same performance as M2.1 with significantly faster inference (~100 tps)",
-        "context_length": 204800,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "MiniMax-M2",
-        "name": "MiniMax M2",
-        "description": "Agentic capabilities with advanced reasoning, function calling, and real-time streaming",
         "context_length": 204800,
         "tools_supported": true,
         "supports_parallel_tool_calls": true,


### PR DESCRIPTION
## Summary

Updates the MiniMax provider model catalog in `crates/forge_repo/src/provider/provider.json`:

- **Add** `MiniMax-M3` as the new top-of-list (default) entry — the latest generation MiniMax model with enhanced reasoning, function calling, and an extended (1M) context window.
- **Keep** `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as legacy options for users still on the previous generation.
- **Remove** the deprecated entries: `MiniMax-M2`, `MiniMax-M2.1`, `MiniMax-M2.1-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`. These are no longer recommended for new sessions; the M2.7 line covers the same use cases at parity or better quality.

This follows the same minimal-edit pattern used for prior model catalog updates (e.g. #2727, #2701, #2597, #2557). Other knobs — base URL (`api.minimax.io`), `MINIMAX_API_KEY` env var, the OpenRouter `SetMinimaxParams` transformer, and OpenCode model routing — are intentionally untouched.

## Why

`MiniMax-M3` is the current production model at MiniMax and outperforms the M2.x line on coding/agentic benchmarks. Surfacing it as the default lets new users pick it up automatically; pruning the older entries keeps the picker focused on the models that are still recommended.

## Changes

- `crates/forge_repo/src/provider/provider.json` — only the `id: "minimax"` `models` array is touched. 9 insertions / 49 deletions, all data-only (no schema changes).

## Test plan

- [ ] `cargo check -p forge_repo` passes (data-only edit; existing `ProviderConfig` schema is unchanged).
- [ ] `cargo test -p forge_repo` — `test_load_provider_configs` still loads the catalog; no minimax-specific assertions exist that depend on the removed model IDs.
- [ ] Manual: `forge` lists `MiniMax-M3` first under the MiniMax provider; selecting it routes through the existing Anthropic-compatible endpoint without code changes.