### PR TITLE
fix(editor): strip ANSI from rustyline prompt raw() so the cursor tracks on Windows

### DIFF
--- a/crates/forge_main/src/editor.rs
+++ b/crates/forge_main/src/editor.rs
@@ -131,24 +131,34 @@ fn render_prompt(prompt: &ForgePrompt) -> ResponsivePrompt {
     let right = prompt.render_prompt_right();
     let right = right.trim_start();
 
+    // `raw` is what rustyline measures to position the cursor; `styled` is what
+    // it prints. `raw` MUST be free of ANSI escapes: rustyline's Windows
+    // console backend computes cursor columns by counting grapheme widths of
+    // `raw` (it cannot interpret escape sequences and debug-asserts against
+    // them), so any styling left in `raw` is counted as visible width and
+    // pushes the cursor past where the text actually is. The left prompt and
+    // indicator are styled via `nu_ansi_term`, so strip those codes for `raw`.
+    // The right prompt is positioned off to the side with cursor save/restore
+    // and is not part of the input-line geometry, so it is excluded from `raw`
+    // entirely.
     if right.trim().is_empty() {
-        let prompt = format!("{left}{indicator}");
-        return ResponsivePrompt { raw: prompt.clone(), styled: prompt };
+        let styled = format!("{left}{indicator}");
+        let raw = strip_ansi_codes(&styled).into_owned();
+        return ResponsivePrompt { raw, styled };
     }
 
     if let Some((first_line, remaining)) = left.split_once('\n') {
         let right = render_right_prompt(right);
+        let raw = strip_ansi_codes(&format!("{first_line}\n{remaining}{indicator}")).into_owned();
         return ResponsivePrompt {
-            raw: format!("{first_line}\n{remaining}{indicator}"),
+            raw,
             styled: format!("{first_line}{right}\n{remaining}{indicator}"),
         };
     }
 
     let right = render_right_prompt(right);
-    ResponsivePrompt {
-        raw: format!("{left}{indicator}"),
-        styled: format!("{left}{right}{indicator}"),
-    }
+    let raw = strip_ansi_codes(&format!("{left}{indicator}")).into_owned();
+    ResponsivePrompt { raw, styled: format!("{left}{right}{indicator}") }
 }
 
 fn render_right_prompt(right: &str) -> String {
@@ -271,5 +281,29 @@ mod tests {
 
         let expected = ReadResult::Success("@[/usr/bin/env]".to_string());
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_render_prompt_raw_has_no_ansi_escapes() {
+        use std::path::PathBuf;
+
+        use forge_api::{AgentId, ModelId};
+
+        // rustyline measures `raw()` to position the cursor and, on Windows,
+        // cannot interpret ANSI escapes (it counts their bytes as visible
+        // columns). `raw()` must therefore be free of escape sequences even
+        // though the visible prompt is styled.
+        let mut prompt = ForgePrompt::new(PathBuf::from("project"), AgentId::default());
+        prompt.model(ModelId::new("anthropic/claude-opus-4"));
+
+        let rendered = render_prompt(&prompt);
+
+        assert!(
+            !rendered.raw.contains('\u{1b}'),
+            "raw prompt must not contain ANSI escape sequences: {:?}",
+            rendered.raw
+        );
+        // The styled prompt, by contrast, does carry styling for display.
+        assert!(rendered.styled.contains('\u{1b}'));
     }
 }


### PR DESCRIPTION
## Problem

On Windows, typing in the interactive prompt desyncs the cursor. The input is *received* correctly, but rendered in the wrong columns — e.g. typing `:version` shows up as `:v      ersion` (the command still parses fine; only the display/cursor is wrong). The cursor also starts a few columns to the right of the prompt.

Reproduces in both Windows Terminal and `cmd`.

## Root cause

rustyline's Windows console backend positions the cursor through the Win32 Console API and computes columns itself in `calculate_position` (`tty/windows.rs`), counting grapheme widths. It **cannot** interpret ANSI escapes — it even `debug_assert!`s that the measured string contains no `\x1b[` (`"content should not be styled directly"`).

The prompt's contribution to the cursor is measured from `Prompt::raw()` (`edit.rs`: `calculate_position(prompt.raw(), …)`). Since #3399 (reedline → rustyline), `ForgePrompt`'s `raw()` was built from `nu_ansi_term`-painted (styled) text, so every SGR escape byte was counted as a *visible column*, pushing the cursor past the typed text.

- In **debug** builds this aborts at startup with `content should not be styled directly`.
- In **release** builds the assert is compiled out, so it silently miscounts — the shipped symptom.

## Fix

`raw()` now returns the ANSI-stripped string (it's only used for measurement); `styled()` keeps the colors (and the right prompt) for display. This mirrors the existing Windows handling already noted in `forge_select/src/input.rs`.

Adds a regression test asserting `render_prompt(…).raw` contains no escape sequences (while `styled` still does).

## Testing

- `cargo test -p forge_main` — new test `test_render_prompt_raw_has_no_ansi_escapes` passes.
- Manually verified on Windows 11 (Windows Terminal + cmd): cursor tracks correctly while typing; the right-aligned status prompt still renders.
- No behavioral change on macOS/Linux (their rustyline backend already handles ANSI; `raw()` content is only ever measured).
