### PR TITLE
fix(select): ignore key Release events so pickers do not close instantly on Windows

### DIFF
--- a/crates/forge_select/src/preview.rs
+++ b/crates/forge_select/src/preview.rs
@@ -8,8 +8,8 @@ use std::{cmp, fmt};
 use bstr::ByteSlice;
 use crossterm::cursor::{Hide, MoveTo, MoveToColumn, MoveUp, Show};
 use crossterm::event::{
-    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyModifiers,
-    MouseEventKind,
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
+    KeyModifiers, MouseEventKind,
 };
 use crossterm::style::{
     Attribute, Color, Print, ResetColor, SetAttribute, SetBackgroundColor, SetForegroundColor,
@@ -435,6 +435,12 @@ fn run_select_ui_values(options: SelectUiOptions) -> anyhow::Result<Option<Vec<S
 
         if event::poll(Duration::from_millis(250))? {
             match event::read()? {
+                // On Windows, crossterm reports key Release events in addition
+                // to Press/Repeat (Unix reports only Press). Ignore Release so a
+                // stray Release — notably the Release of the Enter key that
+                // opened this picker — isn't read as a fresh keystroke that
+                // instantly accepts the default selection and closes the picker.
+                Event::Key(key) if key.kind == KeyEventKind::Release => {}
                 Event::Key(key) => {
                     match handle_key_event(
                         key,


### PR DESCRIPTION
## Problem

On Windows, the interactive fuzzy pickers — `:model`, `:provider`, and friends — flash open and immediately exit, auto-selecting whatever item was highlighted (e.g. `:model` "switches" to the model that was already active).

Reproduces in both Windows Terminal and `cmd`.

## Root cause

crossterm reports `Press`, `Repeat`, **and** `Release` key events on Windows, whereas Unix reports only `Press`. The picker event loop in `preview.rs` matched key events with `KeyEvent { code: …, .. }`, ignoring the `kind` field. So the **`Release`** of the Enter key that was pressed to launch the command (e.g. `:model`) arrived in the freshly-opened picker loop and matched `KeyCode::Enter => PickerAction::Accept`, instantly accepting the default selection and closing the picker.

This is the same Windows key-event class previously handled in #3286 (`skip selector keyboard enhancement on windows`).

## Fix

Ignore `KeyEventKind::Release` events in the picker event loop; `Press`/`Repeat` are handled exactly as before.

```rust
Event::Key(key) if key.kind == KeyEventKind::Release => {}
Event::Key(key) => { /* handle_key_event(...) */ }
```

## Testing

- Manually verified on Windows 11 (Windows Terminal + cmd): `:model` and `:provider` pickers now stay open; ↑/↓ navigation, fuzzy filtering, Enter (select), and Esc (cancel) all work.
- No change on macOS/Linux, where `Release` events aren't emitted.
