### PR TITLE
fix(zsh): stop the prompt redraw from clobbering action output

### DIFF
--- a/shell-plugin/lib/dispatcher.zsh
+++ b/shell-plugin/lib/dispatcher.zsh
@@ -118,11 +118,12 @@ function forge-accept-line() {
     # Add the original command to history before transformation
     print -s -- "$original_buffer"
     
-    # CRITICAL: Move cursor to end so output doesn't overwrite
-    # Don't clear BUFFER yet - let _forge_reset do that after action completes
-    # This keeps buffer state consistent if Ctrl+C is pressed
-    CURSOR=${#BUFFER}
-    zle redisplay
+    # CRITICAL: clear and invalidate the active ZLE prompt before writing output.
+    # Otherwise RPROMPT/text from the old prompt can remain on wrapped rows and
+    # the command output can run underneath it, which looks like clipping.
+    BUFFER=""
+    CURSOR=0
+    zle -I
     
     # Handle aliases - convert to their actual agent names
     case "$user_action" in

--- a/shell-plugin/lib/helpers.zsh
+++ b/shell-plugin/lib/helpers.zsh
@@ -137,12 +137,20 @@ function _forge_select_model_pair_global() {
 }
 
 function _forge_reset() {
-  # Clear buffer and reset cursor position
   BUFFER=""
   CURSOR=0
-  # Force widget redraw and prompt reset
+  # Output may finish without a trailing newline. If ZLE accepts an empty line
+  # from that position, RPROMPT can be painted on top of the final output row.
+  # Move to a clean line before accepting the empty buffer so the next prompt
+  # is always rendered below Forge output.
+  print -r -- "" >/dev/tty
+
+  # Do not accept an empty command line here. accept-line asks ZLE to render the
+  # next prompt from inside the widget; with right prompts (p10k/RPROMPT) that
+  # repaint can still target the last output row and hide the tail of output.
+  # Invalidating the display is enough: the widget returns and zsh redraws the
+  # prompt naturally on the clean line above.
   zle -I
-  zle reset-prompt
 }
 
 # Helper function to print messages with consistent formatting based on log level


### PR DESCRIPTION
Fixes #3468.

The zsh integration clips the last lines of a response on kitty + p10k. `_forge_reset` runs after the output is already on the tty, but ZLE still has the cursor on the old prompt row, so `zle reset-prompt` redraws the prompt over it and the response looks cut off.

Buffer is always empty in `_forge_reset`, so accepting the empty line gives a clean prompt below the output:

```zsh
function _forge_reset() {
  BUFFER=""
  CURSOR=0
  zle .accept-line
}
```

Left the other `reset-prompt` callers (suggest/commit-preview/completion) as-is since they populate the buffer and redraw in place.

Same root cause as #3144/#2893; #3178 fixed the spinner but not this path. Tested on kitty + Powerlevel10k, and suggest/commit/completion still behave.
