### PR TITLE
fix(provider): claude-fable-5 to vertex_ai_anthropic models

### DIFF
--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -2266,6 +2266,16 @@
     "url": "{{#if (eq LOCATION \"global\")}}https://aiplatform.googleapis.com/v1/projects/{{PROJECT_ID}}/locations/{{LOCATION}}/publishers/anthropic/models/{{else}}https://{{LOCATION}}-aiplatform.googleapis.com/v1/projects/{{PROJECT_ID}}/locations/{{LOCATION}}/publishers/anthropic/models/{{/if}}",
     "models": [
       {
+        "id": "claude-fable-5",
+        "name": "Claude Fable 5",
+        "description": "Most capable widely released model for demanding reasoning and agentic work",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
         "id": "claude-opus-4-8",
         "name": "Claude Opus 4.8",
         "description": "",


### PR DESCRIPTION
The claude-fable-5 model was only added to the claude_code provider's static model list, but was omitted from the vertex_ai_anthropic provider. As a result, Claude Fable 5 does not appear in the model picker when using Forge via Vertex AI, even though the model is available on Vertex.

Mirror the claude_code definition into the vertex_ai_anthropic static models array so it surfaces for Vertex AI users.