### PR TITLE
fix: use interactive exec for custom command execution

### DIFF
--- a/shell-plugin/lib/dispatcher.zsh
+++ b/shell-plugin/lib/dispatcher.zsh
@@ -39,9 +39,9 @@ function _forge_action_default() {
                 echo
                 # Execute custom command with execute subcommand
                 if [[ -n "$input_text" ]]; then
-                    _forge_exec cmd execute --cid "$_FORGE_CONVERSATION_ID" "$user_action" "$input_text"
+                    _forge_exec_interactive cmd execute --cid "$_FORGE_CONVERSATION_ID" "$user_action" "$input_text"
                 else
-                    _forge_exec cmd execute --cid "$_FORGE_CONVERSATION_ID" "$user_action"
+                    _forge_exec_interactive cmd execute --cid "$_FORGE_CONVERSATION_ID" "$user_action"
                 fi
                 return 0
             fi


### PR DESCRIPTION
## Summary
Fix custom command execution to use interactive exec, ensuring proper terminal handling when running custom commands through the shell plugin.

## Context
When executing custom commands via the shell plugin's dispatcher (`:command` syntax), the `_forge_exec` function was being used instead of `_forge_exec_interactive`. This meant custom commands were missing interactive terminal capabilities (like proper pty handling, signal forwarding, and real-time output streaming) that are already present for default agent execution at `dispatcher.zsh:82`.

## Changes
- Replaced `_forge_exec` calls with `_forge_exec_interactive` in the custom command branch of `_forge_action_default`
- Applies to both the case with input text and without input text

### Key Implementation Details
The `_forge_exec_interactive` function provides a proper interactive terminal session with pty support, while `_forge_exec` is a simpler non-interactive execution. Custom commands benefit from the same interactive capabilities as the default agent path, which already uses `_forge_exec_interactive`.

## Testing
```bash
# Source the updated shell plugin
source shell-plugin/lib/dispatcher.zsh

# Run a custom command (requires a custom command to be defined)
# Verify output streams properly with real-time display
:my-custom-command some input text

# Verify without input text
:my-custom-command
```
