### PR TITLE
fix: show only direct conversation initiated by the user via the `:conversation` command

### DIFF
--- a/crates/forge_app/src/fmt/todo_fmt.rs
+++ b/crates/forge_app/src/fmt/todo_fmt.rs
@@ -21,7 +21,7 @@ fn format_todo_line(todo: &Todo, line_style: TodoLineStyle) -> String {
         TodoStatus::Completed => "󰄵",
         TodoStatus::InProgress => "󰄗",
         TodoStatus::Pending => "󰄱",
-        TodoStatus::Cancelled => "󰅙",
+        TodoStatus::Cancelled => "",
     };
 
     let content = match todo.status {

--- a/crates/forge_main/src/cli.rs
+++ b/crates/forge_main/src/cli.rs
@@ -1811,7 +1811,10 @@ mod tests {
         ]);
         let is_delete_with_id = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => {
-                matches!(conversation.command, Some(ConversationCommand::Delete { id: _ }))
+                matches!(
+                    conversation.command,
+                    Some(ConversationCommand::Delete { id: _ })
+                )
             }
             _ => false,
         };

--- a/crates/forge_main/src/cli.rs
+++ b/crates/forge_main/src/cli.rs
@@ -1106,9 +1106,7 @@ mod tests {
             },
             _ => None,
         };
-        let expected = Some(
-            ConversationId::parse("550e8400-e29b-41d4-a716-446655440004").unwrap(),
-        );
+        let expected = Some(ConversationId::parse("550e8400-e29b-41d4-a716-446655440004").unwrap());
         assert_eq!(actual, expected);
     }
 

--- a/crates/forge_main/src/cli.rs
+++ b/crates/forge_main/src/cli.rs
@@ -454,7 +454,11 @@ pub enum ListCommand {
 
     /// List conversation history.
     #[command(alias = "session")]
-    Conversation,
+    Conversation {
+        /// Show child conversations of a parent conversation.
+        #[arg(long)]
+        parent: Option<ConversationId>,
+    },
 
     /// List custom commands.
     #[command(alias = "cmds")]
@@ -703,10 +707,6 @@ pub enum ConfigGetField {
 /// Command group for conversation management.
 #[derive(Parser, Debug, Clone)]
 pub struct ConversationCommandGroup {
-    /// List child conversations of a parent conversation.
-    #[arg(long)]
-    pub parent: Option<ConversationId>,
-
     #[command(subcommand)]
     pub command: Option<ConversationCommand>,
 }
@@ -760,11 +760,6 @@ pub enum ConversationCommand {
         md: bool,
     },
 
-    /// Show nested conversations spawned by a conversation.
-    Tree {
-        /// Conversation ID.
-        id: ConversationId,
-    },
 
     /// Show conversation details.
     Info {
@@ -1095,25 +1090,6 @@ mod tests {
     }
 
     #[test]
-    fn test_conversation_tree() {
-        let fixture = Cli::parse_from([
-            "forge",
-            "conversation",
-            "tree",
-            "550e8400-e29b-41d4-a716-446655440004",
-        ]);
-        let actual = match fixture.subcommands {
-            Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                Some(ConversationCommand::Tree { id }) => Some(id),
-                _ => None,
-            },
-            _ => None,
-        };
-        let expected = Some(ConversationId::parse("550e8400-e29b-41d4-a716-446655440004").unwrap());
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
     fn test_session_alias_list() {
         let fixture = Cli::parse_from(["forge", "session", "list"]);
         let is_list = match fixture.subcommands {
@@ -1321,7 +1297,7 @@ mod tests {
     fn test_list_conversation_command() {
         let fixture = Cli::parse_from(["forge", "list", "conversation"]);
         let is_conversation_list = match fixture.subcommands {
-            Some(TopLevelCommand::List(list)) => matches!(list.command, ListCommand::Conversation),
+            Some(TopLevelCommand::List(list)) => matches!(list.command, ListCommand::Conversation { .. }),
             _ => false,
         };
         assert_eq!(is_conversation_list, true);
@@ -1331,7 +1307,7 @@ mod tests {
     fn test_list_session_alias_command() {
         let fixture = Cli::parse_from(["forge", "list", "session"]);
         let is_conversation_list = match fixture.subcommands {
-            Some(TopLevelCommand::List(list)) => matches!(list.command, ListCommand::Conversation),
+            Some(TopLevelCommand::List(list)) => matches!(list.command, ListCommand::Conversation { .. }),
             _ => false,
         };
         assert_eq!(is_conversation_list, true);

--- a/crates/forge_main/src/cli.rs
+++ b/crates/forge_main/src/cli.rs
@@ -764,7 +764,6 @@ pub enum ConversationCommand {
         md: bool,
     },
 
-
     /// Show conversation details.
     Info {
         /// Conversation ID.
@@ -1301,7 +1300,9 @@ mod tests {
     fn test_list_conversation_command() {
         let fixture = Cli::parse_from(["forge", "list", "conversation"]);
         let is_conversation_list = match fixture.subcommands {
-            Some(TopLevelCommand::List(list)) => matches!(list.command, ListCommand::Conversation { .. }),
+            Some(TopLevelCommand::List(list)) => {
+                matches!(list.command, ListCommand::Conversation { .. })
+            }
             _ => false,
         };
         assert_eq!(is_conversation_list, true);
@@ -1311,7 +1312,9 @@ mod tests {
     fn test_list_session_alias_command() {
         let fixture = Cli::parse_from(["forge", "list", "session"]);
         let is_conversation_list = match fixture.subcommands {
-            Some(TopLevelCommand::List(list)) => matches!(list.command, ListCommand::Conversation { .. }),
+            Some(TopLevelCommand::List(list)) => {
+                matches!(list.command, ListCommand::Conversation { .. })
+            }
             _ => false,
         };
         assert_eq!(is_conversation_list, true);

--- a/crates/forge_main/src/cli.rs
+++ b/crates/forge_main/src/cli.rs
@@ -703,8 +703,12 @@ pub enum ConfigGetField {
 /// Command group for conversation management.
 #[derive(Parser, Debug, Clone)]
 pub struct ConversationCommandGroup {
+    /// List child conversations of a parent conversation.
+    #[arg(long)]
+    pub parent: Option<ConversationId>,
+
     #[command(subcommand)]
-    pub command: ConversationCommand,
+    pub command: Option<ConversationCommand>,
 }
 
 #[derive(Subcommand, Debug, Clone)]

--- a/crates/forge_main/src/cli.rs
+++ b/crates/forge_main/src/cli.rs
@@ -757,6 +757,12 @@ pub enum ConversationCommand {
         md: bool,
     },
 
+    /// Show nested conversations spawned by a conversation.
+    Tree {
+        /// Conversation ID.
+        id: ConversationId,
+    },
+
     /// Show conversation details.
     Info {
         /// Conversation ID.
@@ -1083,6 +1089,27 @@ mod tests {
             _ => false,
         };
         assert_eq!(is_list, true);
+    }
+
+    #[test]
+    fn test_conversation_tree() {
+        let fixture = Cli::parse_from([
+            "forge",
+            "conversation",
+            "tree",
+            "550e8400-e29b-41d4-a716-446655440004",
+        ]);
+        let actual = match fixture.subcommands {
+            Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
+                ConversationCommand::Tree { id } => Some(id),
+                _ => None,
+            },
+            _ => None,
+        };
+        let expected = Some(
+            ConversationId::parse("550e8400-e29b-41d4-a716-446655440004").unwrap(),
+        );
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/crates/forge_main/src/cli.rs
+++ b/crates/forge_main/src/cli.rs
@@ -710,7 +710,6 @@ pub struct ConversationCommandGroup {
     #[command(subcommand)]
     pub command: Option<ConversationCommand>,
 }
-
 #[derive(Subcommand, Debug, Clone)]
 pub enum ConversationCommand {
     /// List conversation history.
@@ -1088,7 +1087,7 @@ mod tests {
         let fixture = Cli::parse_from(["forge", "conversation", "list"]);
         let is_list = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => {
-                matches!(conversation.command, ConversationCommand::List { .. })
+                matches!(conversation.command, Some(ConversationCommand::List { .. }))
             }
             _ => false,
         };
@@ -1105,7 +1104,7 @@ mod tests {
         ]);
         let actual = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                ConversationCommand::Tree { id } => Some(id),
+                Some(ConversationCommand::Tree { id }) => Some(id),
                 _ => None,
             },
             _ => None,
@@ -1119,7 +1118,7 @@ mod tests {
         let fixture = Cli::parse_from(["forge", "session", "list"]);
         let is_list = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => {
-                matches!(conversation.command, ConversationCommand::List { .. })
+                matches!(conversation.command, Some(ConversationCommand::List { .. }))
             }
             _ => false,
         };
@@ -1161,7 +1160,7 @@ mod tests {
         ]);
         let (id, html) = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                ConversationCommand::Dump { id, html } => (id, html),
+                Some(ConversationCommand::Dump { id, html }) => (id, html),
                 _ => (ConversationId::default(), true),
             },
             _ => (ConversationId::default(), true),
@@ -1184,7 +1183,7 @@ mod tests {
         ]);
         let (id, html) = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                ConversationCommand::Dump { id, html } => (id, html),
+                Some(ConversationCommand::Dump { id, html }) => (id, html),
                 _ => (ConversationId::default(), false),
             },
             _ => (ConversationId::default(), false),
@@ -1206,7 +1205,7 @@ mod tests {
         ]);
         let id = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                ConversationCommand::Retry { id } => id,
+                Some(ConversationCommand::Retry { id }) => id,
                 _ => ConversationId::default(),
             },
             _ => ConversationId::default(),
@@ -1227,7 +1226,7 @@ mod tests {
         ]);
         let id = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                ConversationCommand::Compact { id } => id,
+                Some(ConversationCommand::Compact { id }) => id,
                 _ => ConversationId::default(),
             },
             _ => ConversationId::default(),
@@ -1248,7 +1247,7 @@ mod tests {
         ]);
         let (id, md) = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                ConversationCommand::Show { id, md } => (id, md),
+                Some(ConversationCommand::Show { id, md }) => (id, md),
                 _ => (ConversationId::default(), false),
             },
             _ => (ConversationId::default(), false),
@@ -1271,7 +1270,7 @@ mod tests {
         ]);
         let (id, md) = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                ConversationCommand::Show { id, md } => (id, md),
+                Some(ConversationCommand::Show { id, md }) => (id, md),
                 _ => (ConversationId::default(), false),
             },
             _ => (ConversationId::default(), false),
@@ -1293,7 +1292,7 @@ mod tests {
         ]);
         let id = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                ConversationCommand::Resume { id } => id,
+                Some(ConversationCommand::Resume { id }) => id,
                 _ => ConversationId::default(),
             },
             _ => ConversationId::default(),
@@ -1508,7 +1507,7 @@ mod tests {
         let fixture = Cli::parse_from(["forge", "conversation", "list", "--porcelain"]);
         let actual = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                ConversationCommand::List { porcelain } => porcelain,
+                Some(ConversationCommand::List { porcelain }) => porcelain,
                 _ => false,
             },
             _ => false,
@@ -1549,7 +1548,7 @@ mod tests {
         ]);
         let id = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                ConversationCommand::Info { id } => id,
+                Some(ConversationCommand::Info { id }) => id,
                 _ => ConversationId::default(),
             },
             _ => ConversationId::default(),
@@ -1571,7 +1570,7 @@ mod tests {
         ]);
         let (id, porcelain) = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                ConversationCommand::Stats { id, porcelain } => (id, porcelain),
+                Some(ConversationCommand::Stats { id, porcelain }) => (id, porcelain),
                 _ => (ConversationId::default(), false),
             },
             _ => (ConversationId::default(), false),
@@ -1603,7 +1602,7 @@ mod tests {
         ]);
         let (id, html) = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                ConversationCommand::Dump { id, html } => (id, html),
+                Some(ConversationCommand::Dump { id, html }) => (id, html),
                 _ => (ConversationId::default(), true),
             },
             _ => (ConversationId::default(), true),
@@ -1625,7 +1624,7 @@ mod tests {
         ]);
         let id = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                ConversationCommand::Retry { id } => id,
+                Some(ConversationCommand::Retry { id }) => id,
                 _ => ConversationId::default(),
             },
             _ => ConversationId::default(),
@@ -1672,7 +1671,7 @@ mod tests {
         ]);
         let id = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                ConversationCommand::Clone { id, .. } => id,
+                Some(ConversationCommand::Clone { id, .. }) => id,
                 _ => ConversationId::default(),
             },
             _ => ConversationId::default(),
@@ -1694,7 +1693,7 @@ mod tests {
         ]);
         let (id, porcelain) = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                ConversationCommand::Clone { id, porcelain } => (id, porcelain),
+                Some(ConversationCommand::Clone { id, porcelain }) => (id, porcelain),
                 _ => (ConversationId::default(), false),
             },
             _ => (ConversationId::default(), false),
@@ -1812,7 +1811,7 @@ mod tests {
         ]);
         let is_delete_with_id = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => {
-                matches!(conversation.command, ConversationCommand::Delete { id: _ })
+                matches!(conversation.command, Some(ConversationCommand::Delete { id: _ }))
             }
             _ => false,
         };

--- a/crates/forge_main/src/cli.rs
+++ b/crates/forge_main/src/cli.rs
@@ -712,7 +712,7 @@ pub enum ConfigGetField {
 #[derive(Parser, Debug, Clone)]
 pub struct ConversationCommandGroup {
     #[command(subcommand)]
-    pub command: Option<ConversationCommand>,
+    pub command: ConversationCommand,
 }
 #[derive(Subcommand, Debug, Clone)]
 pub enum ConversationCommand {
@@ -1085,7 +1085,7 @@ mod tests {
         let fixture = Cli::parse_from(["forge", "conversation", "list"]);
         let is_list = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => {
-                matches!(conversation.command, Some(ConversationCommand::List { .. }))
+                matches!(conversation.command, ConversationCommand::List { .. })
             }
             _ => false,
         };
@@ -1097,7 +1097,7 @@ mod tests {
         let fixture = Cli::parse_from(["forge", "session", "list"]);
         let is_list = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => {
-                matches!(conversation.command, Some(ConversationCommand::List { .. }))
+                matches!(conversation.command, ConversationCommand::List { .. })
             }
             _ => false,
         };
@@ -1139,7 +1139,7 @@ mod tests {
         ]);
         let (id, html) = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                Some(ConversationCommand::Dump { id, html }) => (id, html),
+                ConversationCommand::Dump { id, html } => (id, html),
                 _ => (ConversationId::default(), true),
             },
             _ => (ConversationId::default(), true),
@@ -1162,7 +1162,7 @@ mod tests {
         ]);
         let (id, html) = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                Some(ConversationCommand::Dump { id, html }) => (id, html),
+                ConversationCommand::Dump { id, html } => (id, html),
                 _ => (ConversationId::default(), false),
             },
             _ => (ConversationId::default(), false),
@@ -1184,7 +1184,7 @@ mod tests {
         ]);
         let id = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                Some(ConversationCommand::Retry { id }) => id,
+                ConversationCommand::Retry { id } => id,
                 _ => ConversationId::default(),
             },
             _ => ConversationId::default(),
@@ -1205,7 +1205,7 @@ mod tests {
         ]);
         let id = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                Some(ConversationCommand::Compact { id }) => id,
+                ConversationCommand::Compact { id } => id,
                 _ => ConversationId::default(),
             },
             _ => ConversationId::default(),
@@ -1226,7 +1226,7 @@ mod tests {
         ]);
         let (id, md) = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                Some(ConversationCommand::Show { id, md }) => (id, md),
+                ConversationCommand::Show { id, md } => (id, md),
                 _ => (ConversationId::default(), false),
             },
             _ => (ConversationId::default(), false),
@@ -1249,7 +1249,7 @@ mod tests {
         ]);
         let (id, md) = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                Some(ConversationCommand::Show { id, md }) => (id, md),
+                ConversationCommand::Show { id, md } => (id, md),
                 _ => (ConversationId::default(), false),
             },
             _ => (ConversationId::default(), false),
@@ -1271,7 +1271,7 @@ mod tests {
         ]);
         let id = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                Some(ConversationCommand::Resume { id }) => id,
+                ConversationCommand::Resume { id } => id,
                 _ => ConversationId::default(),
             },
             _ => ConversationId::default(),
@@ -1490,7 +1490,7 @@ mod tests {
         let fixture = Cli::parse_from(["forge", "conversation", "list", "--porcelain"]);
         let actual = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                Some(ConversationCommand::List { porcelain }) => porcelain,
+                ConversationCommand::List { porcelain } => porcelain,
                 _ => false,
             },
             _ => false,
@@ -1531,7 +1531,7 @@ mod tests {
         ]);
         let id = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                Some(ConversationCommand::Info { id }) => id,
+                ConversationCommand::Info { id } => id,
                 _ => ConversationId::default(),
             },
             _ => ConversationId::default(),
@@ -1553,7 +1553,7 @@ mod tests {
         ]);
         let (id, porcelain) = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                Some(ConversationCommand::Stats { id, porcelain }) => (id, porcelain),
+                ConversationCommand::Stats { id, porcelain } => (id, porcelain),
                 _ => (ConversationId::default(), false),
             },
             _ => (ConversationId::default(), false),
@@ -1585,7 +1585,7 @@ mod tests {
         ]);
         let (id, html) = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                Some(ConversationCommand::Dump { id, html }) => (id, html),
+                ConversationCommand::Dump { id, html } => (id, html),
                 _ => (ConversationId::default(), true),
             },
             _ => (ConversationId::default(), true),
@@ -1607,7 +1607,7 @@ mod tests {
         ]);
         let id = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                Some(ConversationCommand::Retry { id }) => id,
+                ConversationCommand::Retry { id } => id,
                 _ => ConversationId::default(),
             },
             _ => ConversationId::default(),
@@ -1654,7 +1654,7 @@ mod tests {
         ]);
         let id = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                Some(ConversationCommand::Clone { id, .. }) => id,
+                ConversationCommand::Clone { id, .. } => id,
                 _ => ConversationId::default(),
             },
             _ => ConversationId::default(),
@@ -1676,7 +1676,7 @@ mod tests {
         ]);
         let (id, porcelain) = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
-                Some(ConversationCommand::Clone { id, porcelain }) => (id, porcelain),
+                ConversationCommand::Clone { id, porcelain } => (id, porcelain),
                 _ => (ConversationId::default(), false),
             },
             _ => (ConversationId::default(), false),
@@ -1796,7 +1796,7 @@ mod tests {
             Some(TopLevelCommand::Conversation(conversation)) => {
                 matches!(
                     conversation.command,
-                    Some(ConversationCommand::Delete { id: _ })
+                    ConversationCommand::Delete { id: _ }
                 )
             }
             _ => false,

--- a/crates/forge_main/src/cli.rs
+++ b/crates/forge_main/src/cli.rs
@@ -237,6 +237,10 @@ pub enum SelectCommand {
         /// Initial query text pre-filled in the search box.
         #[arg(long, short = 'q')]
         query: Option<String>,
+
+        /// Show child conversations of a parent conversation.
+        #[arg(long)]
+        parent: Option<ConversationId>,
     },
 
     /// Select a file interactively with a preview pane.

--- a/crates/forge_main/src/cli.rs
+++ b/crates/forge_main/src/cli.rs
@@ -1794,10 +1794,7 @@ mod tests {
         ]);
         let is_delete_with_id = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => {
-                matches!(
-                    conversation.command,
-                    ConversationCommand::Delete { id: _ }
-                )
+                matches!(conversation.command, ConversationCommand::Delete { id: _ })
             }
             _ => false,
         };

--- a/crates/forge_main/src/model.rs
+++ b/crates/forge_main/src/model.rs
@@ -114,6 +114,8 @@ impl ForgeCommandManager {
                 | "logout"
                 | "retry"
                 | "conversations"
+                | "conversation-tree"
+                | "ct"
                 | "list"
                 | "commit"
                 | "rename"
@@ -650,6 +652,13 @@ pub enum AppCommand {
         id: Option<String>,
     },
 
+    /// Show nested conversations spawned by the current conversation
+    #[strum(props(
+        usage = "Show nested conversations spawned by the current conversation [alias: ct]"
+    ))]
+    #[command(name = "conversation-tree", alias = "ct")]
+    ConversationTree,
+
     /// Delete a conversation permanently
     #[strum(props(usage = "Delete a conversation permanently"))]
     #[command(skip)]
@@ -716,6 +725,7 @@ impl AppCommand {
             AppCommand::Logout => "logout",
             AppCommand::Retry => "retry",
             AppCommand::Conversations { .. } => "conversation",
+            AppCommand::ConversationTree => "conversation-tree",
             AppCommand::Delete => "delete",
             AppCommand::Rename { .. } => "rename",
             AppCommand::AgentSwitch(agent_id) => agent_id,

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -914,13 +914,13 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
         conversation_group: crate::cli::ConversationCommandGroup,
     ) -> anyhow::Result<()> {
         match conversation_group.command {
-            Some(ConversationCommand::List { porcelain }) => {
+            ConversationCommand::List { porcelain } => {
                 self.on_show_conversations(porcelain).await?;
             }
-            Some(ConversationCommand::New) => {
+            ConversationCommand::New => {
                 self.handle_generate_conversation_id().await?;
             }
-            Some(ConversationCommand::Dump { id, html }) => {
+            ConversationCommand::Dump { id, html } => {
                 self.validate_conversation_exists(&id).await?;
 
                 let original_id = self.state.conversation_id;
@@ -931,7 +931,7 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
 
                 self.state.conversation_id = original_id;
             }
-            Some(ConversationCommand::Compact { id }) => {
+            ConversationCommand::Compact { id } => {
                 self.validate_conversation_exists(&id).await?;
 
                 let original_id = self.state.conversation_id;
@@ -942,7 +942,7 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
 
                 self.state.conversation_id = original_id;
             }
-            Some(ConversationCommand::Delete { id }) => {
+            ConversationCommand::Delete { id } => {
                 let conversation_id =
                     ConversationId::parse(&id).context(format!("Invalid conversation ID: {id}"))?;
 
@@ -950,7 +950,7 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
 
                 self.on_conversation_delete(conversation_id).await?;
             }
-            Some(ConversationCommand::Retry { id }) => {
+            ConversationCommand::Retry { id } => {
                 self.validate_conversation_exists(&id).await?;
 
                 let original_id = self.state.conversation_id;
@@ -961,36 +961,36 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
 
                 self.state.conversation_id = original_id;
             }
-            Some(ConversationCommand::Resume { id }) => {
+            ConversationCommand::Resume { id } => {
                 self.validate_conversation_exists(&id).await?;
 
                 self.state.conversation_id = Some(id);
                 self.writeln_title(TitleFormat::info(format!("Resumed conversation: {id}")))?;
                 // Interactive mode will be handled by the main loop
             }
-            Some(ConversationCommand::Show { id, md }) => {
+            ConversationCommand::Show { id, md } => {
                 let conversation = self.validate_conversation_exists(&id).await?;
 
                 self.on_show_last_message(conversation, md).await?;
             }
-            Some(ConversationCommand::Info { id }) => {
+            ConversationCommand::Info { id } => {
                 let conversation = self.validate_conversation_exists(&id).await?;
 
                 self.on_show_conv_info(conversation).await?;
             }
-            Some(ConversationCommand::Stats { id, porcelain }) => {
+            ConversationCommand::Stats { id, porcelain } => {
                 let conversation = self.validate_conversation_exists(&id).await?;
 
                 self.on_show_conv_stats(conversation, porcelain).await?;
             }
-            Some(ConversationCommand::Clone { id, porcelain }) => {
+            ConversationCommand::Clone { id, porcelain } => {
                 let conversation = self.validate_conversation_exists(&id).await?;
 
                 self.spinner.start(Some("Cloning"))?;
                 self.on_clone_conversation(conversation, porcelain).await?;
                 self.spinner.stop(None)?;
             }
-            Some(ConversationCommand::Rename { id, name }) => {
+            ConversationCommand::Rename { id, name } => {
                 self.validate_conversation_exists(&id).await?;
 
                 let name = name.trim().to_string();
@@ -1005,11 +1005,7 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                     name.bold()
                 )))?;
             }
-            None => {
-                self.on_show_conversations(false).await?;
-            }
         }
-
         Ok(())
     }
 

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -883,11 +883,18 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                             self.select_row_output("Command", query.clone(), rows)?;
                         }
                     }
-                    SelectCommand::Conversation { query } => {
-                        let max_conversations = self.config.max_conversations;
+                    SelectCommand::Conversation { query, parent } => {
                         let conversations =
-                            self.api.get_conversations(Some(max_conversations)).await?;
-                        let conversations = Self::user_initiated_conversations(conversations);
+                            if let Some(parent_id) = parent {
+                                let parent_conv =
+                                    self.validate_conversation_exists(parent_id).await?;
+                                self.fetch_related_conversations(&parent_conv).await
+                            } else {
+                                let max_conversations = self.config.max_conversations;
+                                let conversations =
+                                    self.api.get_conversations(Some(max_conversations)).await?;
+                                Self::user_initiated_conversations(conversations)
+                            };
 
                         if !conversations.is_empty()
                             && let Some(conversation) = ConversationSelector::select_conversation(
@@ -2189,41 +2196,22 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                     self.writeln_title(TitleFormat::info(
                         "No child conversations found.",
                     ))?;
-                } else {
-                    let mut info = Info::new();
-                    for conv in children.into_iter() {
-                        let title = conv
-                            .title
-                            .as_deref()
-                            .map(|t| t.to_string())
-                            .unwrap_or_else(|| markers::EMPTY.to_string());
-
-                        let duration = chrono::Utc::now()
-                            .signed_duration_since(
-                                conv.metadata
-                                    .updated_at
-                                    .unwrap_or(conv.metadata.created_at),
-                            );
-                        let duration = std::time::Duration::from_secs(
-                            (duration.num_minutes() * 60).max(0) as u64,
-                        );
-                        let time_ago = if duration.is_zero() {
-                            "now".to_string()
-                        } else {
-                            format!("{} ago", humantime::format_duration(duration))
-                        };
-
-                        info = info
-                            .add_title(conv.id)
-                            .add_key_value("Title", title)
-                            .add_key_value("Updated", time_ago);
-                    }
-
-                    let porcelain = Porcelain::from(&info)
-                        .drop_col(3)
-                        .truncate(1, 60)
-                        .uppercase_headers();
-                    self.writeln(porcelain)?;
+                } else if let Some(conversation) =
+                    ConversationSelector::select_conversation(
+                        &children,
+                        self.state.conversation_id,
+                        None,
+                    )
+                    .await?
+                {
+                    let conversation_id = conversation.id;
+                    self.state.conversation_id = Some(conversation_id);
+                    self.on_show_last_message(conversation, false).await?;
+                    self.writeln_title(TitleFormat::info(format!(
+                        "Switched to conversation {}",
+                        conversation_id.into_string().bold()
+                    )))?;
+                    self.on_info(false, Some(conversation_id)).await?;
                 }
             }
             AppCommand::Compact => {

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -839,6 +839,7 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                         let max_conversations = self.config.max_conversations;
                         let conversations =
                             self.api.get_conversations(Some(max_conversations)).await?;
+                        let conversations = Self::user_initiated_conversations(conversations);
 
                         if !conversations.is_empty()
                             && let Some(conversation) = ConversationSelector::select_conversation(
@@ -921,6 +922,11 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                 let conversation = self.validate_conversation_exists(&id).await?;
 
                 self.on_show_last_message(conversation, md).await?;
+            }
+            ConversationCommand::Tree { id } => {
+                let conversation = self.validate_conversation_exists(&id).await?;
+
+                self.on_show_conversation_tree(conversation).await?;
             }
             ConversationCommand::Info { id } => {
                 let conversation = self.validate_conversation_exists(&id).await?;
@@ -2032,9 +2038,53 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
         Ok(())
     }
 
+    async fn on_show_conversation_tree(&mut self, root: Conversation) -> anyhow::Result<()> {
+        let mut lines = Vec::new();
+        let mut stack = vec![(root, String::new(), true, true)];
+        let mut visited = HashSet::new();
+
+        while let Some((conversation, prefix, is_last, is_root)) = stack.pop() {
+            if !visited.insert(conversation.id) {
+                continue;
+            }
+
+            let title = conversation
+                .title
+                .as_deref()
+                .map(str::to_string)
+                .unwrap_or_else(|| markers::EMPTY.to_string());
+            let connector = if is_root {
+                String::new()
+            } else if is_last {
+                "└── ".to_string()
+            } else {
+                "├── ".to_string()
+            };
+            lines.push(format!("{prefix}{connector}{} {title}", conversation.id));
+
+            let child_prefix = if is_root {
+                String::new()
+            } else if is_last {
+                format!("{prefix}    ")
+            } else {
+                format!("{prefix}│   ")
+            };
+
+            let children = self.fetch_related_conversations(&conversation).await;
+            let child_count = children.len();
+            for (index, child) in children.into_iter().enumerate().rev() {
+                stack.push((child, child_prefix.clone(), index + 1 == child_count, false));
+            }
+        }
+
+        self.writeln(lines.join("\n"))?;
+        Ok(())
+    }
+
     async fn on_show_conversations(&mut self, porcelain: bool) -> anyhow::Result<()> {
         let max_conversations = self.config.max_conversations;
         let conversations = self.api.get_conversations(Some(max_conversations)).await?;
+        let conversations = Self::user_initiated_conversations(conversations);
 
         if conversations.is_empty() {
             return Ok(());
@@ -2084,6 +2134,25 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
         }
 
         Ok(())
+    }
+
+    fn user_initiated_conversations(conversations: Vec<Conversation>) -> Vec<Conversation> {
+        let related_ids: HashSet<ConversationId> = conversations
+            .iter()
+            .flat_map(Conversation::related_conversation_ids)
+            .collect();
+
+        conversations
+            .into_iter()
+            .filter(|conversation| {
+                conversation
+                    .context
+                    .as_ref()
+                    .and_then(|context| context.initiator.as_deref())
+                    .is_none_or(|initiator| initiator == "user")
+                    && !related_ids.contains(&conversation.id)
+            })
+            .collect()
     }
 
     async fn on_command(&mut self, command: AppCommand) -> anyhow::Result<bool> {

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -2092,6 +2092,49 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
         Ok(())
     }
 
+    /// Displays child conversations of a parent as a flat list
+    async fn on_show_conversation_children(&mut self, parent: Conversation) -> anyhow::Result<()> {
+        let children = self.fetch_related_conversations(&parent).await;
+
+        if children.is_empty() {
+            self.writeln_title(TitleFormat::info("No child conversations found."))?;
+            return Ok(());
+        }
+
+        let mut info = Info::new();
+
+        for conv in children.into_iter() {
+            let title = conv
+                .title
+                .as_deref()
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| markers::EMPTY.to_string());
+
+            let duration = chrono::Utc::now().signed_duration_since(
+                conv.metadata.updated_at.unwrap_or(conv.metadata.created_at),
+            );
+            let duration =
+                std::time::Duration::from_secs((duration.num_minutes() * 60).max(0) as u64);
+            let time_ago = if duration.is_zero() {
+                "now".to_string()
+            } else {
+                format!("{} ago", humantime::format_duration(duration))
+            };
+
+            info = info
+                .add_title(conv.id)
+                .add_key_value("Title", title)
+                .add_key_value("Updated", time_ago);
+        }
+
+        let porcelain = Porcelain::from(&info)
+            .drop_col(3)
+            .truncate(1, 60)
+            .uppercase_headers();
+        self.writeln(porcelain)?;
+        Ok(())
+    }
+
     async fn on_show_conversations(&mut self, porcelain: bool) -> anyhow::Result<()> {
         let max_conversations = self.config.max_conversations;
         let conversations = self.api.get_conversations(Some(max_conversations)).await?;

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -501,8 +501,56 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                     ListCommand::Mcp => {
                         self.on_show_mcp_servers(porcelain).await?;
                     }
-                    ListCommand::Conversation => {
-                        self.on_show_conversations(porcelain).await?;
+                    ListCommand::Conversation { parent } => {
+                        if let Some(parent_id) = parent {
+                            let parent_conv =
+                                self.validate_conversation_exists(&parent_id).await?;
+                            let children =
+                                self.fetch_related_conversations(&parent_conv).await;
+
+                            if children.is_empty() {
+                                self.writeln_title(TitleFormat::info(
+                                    "No child conversations found.",
+                                ))?;
+                            } else {
+                                let mut info = Info::new();
+                                for conv in children.into_iter() {
+                                    let title = conv
+                                        .title
+                                        .as_deref()
+                                        .map(|t| t.to_string())
+                                        .unwrap_or_else(|| markers::EMPTY.to_string());
+
+                                    let duration = chrono::Utc::now()
+                                        .signed_duration_since(
+                                            conv.metadata
+                                                .updated_at
+                                                .unwrap_or(conv.metadata.created_at),
+                                        );
+                                    let duration = std::time::Duration::from_secs(
+                                        (duration.num_minutes() * 60).max(0) as u64,
+                                    );
+                                    let time_ago = if duration.is_zero() {
+                                        "now".to_string()
+                                    } else {
+                                        format!("{} ago", humantime::format_duration(duration))
+                                    };
+
+                                    info = info
+                                        .add_title(conv.id)
+                                        .add_key_value("Title", title)
+                                        .add_key_value("Updated", time_ago);
+                                }
+
+                                let porcelain = Porcelain::from(&info)
+                                    .drop_col(3)
+                                    .truncate(1, 60)
+                                    .uppercase_headers();
+                                self.writeln(porcelain)?;
+                            }
+                        } else {
+                            self.on_show_conversations(porcelain).await?;
+                        }
                     }
                     ListCommand::Cmd => {
                         self.on_show_custom_commands(porcelain).await?;
@@ -863,13 +911,6 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
         &mut self,
         conversation_group: crate::cli::ConversationCommandGroup,
     ) -> anyhow::Result<()> {
-        // When --parent is provided, list child conversations of that parent
-        if let Some(parent_id) = conversation_group.parent {
-            let parent = self.validate_conversation_exists(&parent_id).await?;
-            self.on_show_conversation_children(parent).await?;
-            return Ok(());
-        }
-
         match conversation_group.command {
             Some(ConversationCommand::List { porcelain }) => {
                 self.on_show_conversations(porcelain).await?;
@@ -929,11 +970,6 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                 let conversation = self.validate_conversation_exists(&id).await?;
 
                 self.on_show_last_message(conversation, md).await?;
-            }
-            Some(ConversationCommand::Tree { id }) => {
-                let conversation = self.validate_conversation_exists(&id).await?;
-
-                self.on_show_conversation_tree(conversation).await?;
             }
             Some(ConversationCommand::Info { id }) => {
                 let conversation = self.validate_conversation_exists(&id).await?;
@@ -2049,92 +2085,6 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
         Ok(())
     }
 
-    async fn on_show_conversation_tree(&mut self, root: Conversation) -> anyhow::Result<()> {
-        let mut lines = Vec::new();
-        let mut stack = vec![(root, String::new(), true, true)];
-        let mut visited = HashSet::new();
-
-        while let Some((conversation, prefix, is_last, is_root)) = stack.pop() {
-            if !visited.insert(conversation.id) {
-                continue;
-            }
-
-            let title = conversation
-                .title
-                .as_deref()
-                .map(str::to_string)
-                .unwrap_or_else(|| markers::EMPTY.to_string());
-            let connector = if is_root {
-                String::new()
-            } else if is_last {
-                "└── ".to_string()
-            } else {
-                "├── ".to_string()
-            };
-            lines.push(format!("{prefix}{connector}{} {title}", conversation.id));
-
-            let child_prefix = if is_root {
-                String::new()
-            } else if is_last {
-                format!("{prefix}    ")
-            } else {
-                format!("{prefix}│   ")
-            };
-
-            let children = self.fetch_related_conversations(&conversation).await;
-            let child_count = children.len();
-            for (index, child) in children.into_iter().enumerate().rev() {
-                stack.push((child, child_prefix.clone(), index + 1 == child_count, false));
-            }
-        }
-
-        self.writeln(lines.join("\n"))?;
-        Ok(())
-    }
-
-    /// Displays child conversations of a parent as a flat list
-    async fn on_show_conversation_children(&mut self, parent: Conversation) -> anyhow::Result<()> {
-        let children = self.fetch_related_conversations(&parent).await;
-
-        if children.is_empty() {
-            self.writeln_title(TitleFormat::info("No child conversations found."))?;
-            return Ok(());
-        }
-
-        let mut info = Info::new();
-
-        for conv in children.into_iter() {
-            let title = conv
-                .title
-                .as_deref()
-                .map(|t| t.to_string())
-                .unwrap_or_else(|| markers::EMPTY.to_string());
-
-            let duration = chrono::Utc::now().signed_duration_since(
-                conv.metadata.updated_at.unwrap_or(conv.metadata.created_at),
-            );
-            let duration =
-                std::time::Duration::from_secs((duration.num_minutes() * 60).max(0) as u64);
-            let time_ago = if duration.is_zero() {
-                "now".to_string()
-            } else {
-                format!("{} ago", humantime::format_duration(duration))
-            };
-
-            info = info
-                .add_title(conv.id)
-                .add_key_value("Title", title)
-                .add_key_value("Updated", time_ago);
-        }
-
-        let porcelain = Porcelain::from(&info)
-            .drop_col(3)
-            .truncate(1, 60)
-            .uppercase_headers();
-        self.writeln(porcelain)?;
-        Ok(())
-    }
-
     async fn on_show_conversations(&mut self, porcelain: bool) -> anyhow::Result<()> {
         let max_conversations = self.config.max_conversations;
         let conversations = self.api.get_conversations(Some(max_conversations)).await?;
@@ -2232,8 +2182,49 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                     .state
                     .conversation_id
                     .ok_or_else(|| anyhow::anyhow!("No active conversation"))?;
-                let conversation = self.validate_conversation_exists(&conversation_id).await?;
-                self.on_show_conversation_tree(conversation).await?;
+                let parent = self.validate_conversation_exists(&conversation_id).await?;
+                let children = self.fetch_related_conversations(&parent).await;
+
+                if children.is_empty() {
+                    self.writeln_title(TitleFormat::info(
+                        "No child conversations found.",
+                    ))?;
+                } else {
+                    let mut info = Info::new();
+                    for conv in children.into_iter() {
+                        let title = conv
+                            .title
+                            .as_deref()
+                            .map(|t| t.to_string())
+                            .unwrap_or_else(|| markers::EMPTY.to_string());
+
+                        let duration = chrono::Utc::now()
+                            .signed_duration_since(
+                                conv.metadata
+                                    .updated_at
+                                    .unwrap_or(conv.metadata.created_at),
+                            );
+                        let duration = std::time::Duration::from_secs(
+                            (duration.num_minutes() * 60).max(0) as u64,
+                        );
+                        let time_ago = if duration.is_zero() {
+                            "now".to_string()
+                        } else {
+                            format!("{} ago", humantime::format_duration(duration))
+                        };
+
+                        info = info
+                            .add_title(conv.id)
+                            .add_key_value("Title", title)
+                            .add_key_value("Updated", time_ago);
+                    }
+
+                    let porcelain = Porcelain::from(&info)
+                        .drop_col(3)
+                        .truncate(1, 60)
+                        .uppercase_headers();
+                    self.writeln(porcelain)?;
+                }
             }
             AppCommand::Compact => {
                 self.spinner.start(Some("Compacting"))?;

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -503,10 +503,8 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                     }
                     ListCommand::Conversation { parent } => {
                         if let Some(parent_id) = parent {
-                            let parent_conv =
-                                self.validate_conversation_exists(&parent_id).await?;
-                            let children =
-                                self.fetch_related_conversations(&parent_conv).await;
+                            let parent_conv = self.validate_conversation_exists(&parent_id).await?;
+                            let children = self.fetch_related_conversations(&parent_conv).await;
 
                             if children.is_empty() {
                                 self.writeln_title(TitleFormat::info(
@@ -521,12 +519,11 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                                         .map(|t| t.to_string())
                                         .unwrap_or_else(|| markers::EMPTY.to_string());
 
-                                    let duration = chrono::Utc::now()
-                                        .signed_duration_since(
-                                            conv.metadata
-                                                .updated_at
-                                                .unwrap_or(conv.metadata.created_at),
-                                        );
+                                    let duration = chrono::Utc::now().signed_duration_since(
+                                        conv.metadata
+                                            .updated_at
+                                            .unwrap_or(conv.metadata.created_at),
+                                    );
                                     let duration = std::time::Duration::from_secs(
                                         (duration.num_minutes() * 60).max(0) as u64,
                                     );
@@ -884,17 +881,15 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                         }
                     }
                     SelectCommand::Conversation { query, parent } => {
-                        let conversations =
-                            if let Some(parent_id) = parent {
-                                let parent_conv =
-                                    self.validate_conversation_exists(parent_id).await?;
-                                self.fetch_related_conversations(&parent_conv).await
-                            } else {
-                                let max_conversations = self.config.max_conversations;
-                                let conversations =
-                                    self.api.get_conversations(Some(max_conversations)).await?;
-                                Self::user_initiated_conversations(conversations)
-                            };
+                        let conversations = if let Some(parent_id) = parent {
+                            let parent_conv = self.validate_conversation_exists(parent_id).await?;
+                            self.fetch_related_conversations(&parent_conv).await
+                        } else {
+                            let max_conversations = self.config.max_conversations;
+                            let conversations =
+                                self.api.get_conversations(Some(max_conversations)).await?;
+                            Self::user_initiated_conversations(conversations)
+                        };
 
                         if !conversations.is_empty()
                             && let Some(conversation) = ConversationSelector::select_conversation(
@@ -2193,16 +2188,13 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                 let children = self.fetch_related_conversations(&parent).await;
 
                 if children.is_empty() {
-                    self.writeln_title(TitleFormat::info(
-                        "No child conversations found.",
-                    ))?;
-                } else if let Some(conversation) =
-                    ConversationSelector::select_conversation(
-                        &children,
-                        self.state.conversation_id,
-                        None,
-                    )
-                    .await?
+                    self.writeln_title(TitleFormat::info("No child conversations found."))?;
+                } else if let Some(conversation) = ConversationSelector::select_conversation(
+                    &children,
+                    self.state.conversation_id,
+                    None,
+                )
+                .await?
                 {
                     let conversation_id = conversation.id;
                     self.state.conversation_id = Some(conversation_id);

--- a/crates/forge_main/src/ui.rs
+++ b/crates/forge_main/src/ui.rs
@@ -863,14 +863,21 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
         &mut self,
         conversation_group: crate::cli::ConversationCommandGroup,
     ) -> anyhow::Result<()> {
+        // When --parent is provided, list child conversations of that parent
+        if let Some(parent_id) = conversation_group.parent {
+            let parent = self.validate_conversation_exists(&parent_id).await?;
+            self.on_show_conversation_children(parent).await?;
+            return Ok(());
+        }
+
         match conversation_group.command {
-            ConversationCommand::List { porcelain } => {
+            Some(ConversationCommand::List { porcelain }) => {
                 self.on_show_conversations(porcelain).await?;
             }
-            ConversationCommand::New => {
+            Some(ConversationCommand::New) => {
                 self.handle_generate_conversation_id().await?;
             }
-            ConversationCommand::Dump { id, html } => {
+            Some(ConversationCommand::Dump { id, html }) => {
                 self.validate_conversation_exists(&id).await?;
 
                 let original_id = self.state.conversation_id;
@@ -881,7 +888,7 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
 
                 self.state.conversation_id = original_id;
             }
-            ConversationCommand::Compact { id } => {
+            Some(ConversationCommand::Compact { id }) => {
                 self.validate_conversation_exists(&id).await?;
 
                 let original_id = self.state.conversation_id;
@@ -892,7 +899,7 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
 
                 self.state.conversation_id = original_id;
             }
-            ConversationCommand::Delete { id } => {
+            Some(ConversationCommand::Delete { id }) => {
                 let conversation_id =
                     ConversationId::parse(&id).context(format!("Invalid conversation ID: {id}"))?;
 
@@ -900,7 +907,7 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
 
                 self.on_conversation_delete(conversation_id).await?;
             }
-            ConversationCommand::Retry { id } => {
+            Some(ConversationCommand::Retry { id }) => {
                 self.validate_conversation_exists(&id).await?;
 
                 let original_id = self.state.conversation_id;
@@ -911,41 +918,41 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
 
                 self.state.conversation_id = original_id;
             }
-            ConversationCommand::Resume { id } => {
+            Some(ConversationCommand::Resume { id }) => {
                 self.validate_conversation_exists(&id).await?;
 
                 self.state.conversation_id = Some(id);
                 self.writeln_title(TitleFormat::info(format!("Resumed conversation: {id}")))?;
                 // Interactive mode will be handled by the main loop
             }
-            ConversationCommand::Show { id, md } => {
+            Some(ConversationCommand::Show { id, md }) => {
                 let conversation = self.validate_conversation_exists(&id).await?;
 
                 self.on_show_last_message(conversation, md).await?;
             }
-            ConversationCommand::Tree { id } => {
+            Some(ConversationCommand::Tree { id }) => {
                 let conversation = self.validate_conversation_exists(&id).await?;
 
                 self.on_show_conversation_tree(conversation).await?;
             }
-            ConversationCommand::Info { id } => {
+            Some(ConversationCommand::Info { id }) => {
                 let conversation = self.validate_conversation_exists(&id).await?;
 
                 self.on_show_conv_info(conversation).await?;
             }
-            ConversationCommand::Stats { id, porcelain } => {
+            Some(ConversationCommand::Stats { id, porcelain }) => {
                 let conversation = self.validate_conversation_exists(&id).await?;
 
                 self.on_show_conv_stats(conversation, porcelain).await?;
             }
-            ConversationCommand::Clone { id, porcelain } => {
+            Some(ConversationCommand::Clone { id, porcelain }) => {
                 let conversation = self.validate_conversation_exists(&id).await?;
 
                 self.spinner.start(Some("Cloning"))?;
                 self.on_clone_conversation(conversation, porcelain).await?;
                 self.spinner.stop(None)?;
             }
-            ConversationCommand::Rename { id, name } => {
+            Some(ConversationCommand::Rename { id, name }) => {
                 self.validate_conversation_exists(&id).await?;
 
                 let name = name.trim().to_string();
@@ -959,6 +966,9 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                     "Conversation renamed to '{}'",
                     name.bold()
                 )))?;
+            }
+            None => {
+                self.on_show_conversations(false).await?;
             }
         }
 
@@ -2004,6 +2014,7 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
         self.spinner.start(Some("Loading Conversations"))?;
         let max_conversations = self.config.max_conversations;
         let conversations = self.api.get_conversations(Some(max_conversations)).await?;
+        let conversations = Self::user_initiated_conversations(conversations);
         self.spinner.stop(None)?;
 
         if conversations.is_empty() {
@@ -2172,6 +2183,14 @@ impl<A: API + ConsoleWriter + 'static, F: Fn(ForgeConfig) -> A + Send + Sync> UI
                 } else {
                     self.list_conversations().await?;
                 }
+            }
+            AppCommand::ConversationTree => {
+                let conversation_id = self
+                    .state
+                    .conversation_id
+                    .ok_or_else(|| anyhow::anyhow!("No active conversation"))?;
+                let conversation = self.validate_conversation_exists(&conversation_id).await?;
+                self.on_show_conversation_tree(conversation).await?;
             }
             AppCommand::Compact => {
                 self.spinner.start(Some("Compacting"))?;

--- a/shell-plugin/lib/actions/conversation.zsh
+++ b/shell-plugin/lib/actions/conversation.zsh
@@ -6,6 +6,7 @@
 # - :conversation          - List and switch conversations (with interactive picker)
 # - :conversation <id>     - Switch to specific conversation by ID
 # - :conversation -        - Toggle between current and previous conversation (like cd -)
+# - :conversation-tree     - Show nested conversations spawned by current conversation
 # - :clone                 - Clone current or selected conversation
 # - :clone <id>            - Clone specific conversation by ID
 # - :copy                  - Copy last assistant message to OS clipboard as raw markdown
@@ -113,6 +114,11 @@ function _forge_action_conversation() {
         # Print log about conversation switching
         _forge_log success "Switched to conversation \033[1m${conversation_id}\033[0m"
     fi
+}
+
+# Action handler: Show nested conversations spawned by current conversation
+function _forge_action_conversation_tree() {
+    _forge_handle_conversation_command "tree"
 }
 
 # Action handler: Clone conversation

--- a/shell-plugin/lib/actions/conversation.zsh
+++ b/shell-plugin/lib/actions/conversation.zsh
@@ -116,9 +116,10 @@ function _forge_action_conversation() {
     fi
 }
 
+
 # Action handler: Show nested conversations spawned by current conversation
 function _forge_action_conversation_tree() {
-    _forge_handle_conversation_command "tree"
+    _forge_exec list conversation --parent "$_FORGE_CONVERSATION_ID"
 }
 
 # Action handler: Clone conversation

--- a/shell-plugin/lib/actions/conversation.zsh
+++ b/shell-plugin/lib/actions/conversation.zsh
@@ -119,7 +119,7 @@ function _forge_action_conversation() {
 
 # Action handler: Show nested conversations spawned by current conversation
 function _forge_action_conversation_tree() {
-    _forge_exec list conversation --parent "$_FORGE_CONVERSATION_ID"
+    _forge_select conversation --parent "$_FORGE_CONVERSATION_ID"
 }
 
 # Action handler: Clone conversation

--- a/shell-plugin/lib/dispatcher.zsh
+++ b/shell-plugin/lib/dispatcher.zsh
@@ -169,6 +169,9 @@ function forge-accept-line() {
         conversation|c)
             _forge_action_conversation "$input_text"
         ;;
+        conversation-tree|ct)
+            _forge_action_conversation_tree
+        ;;
         config-model|cm)
             _forge_action_model "$input_text"
         ;;


### PR DESCRIPTION
## Summary
Add conversation tree navigation and child list views to browse parent-child conversation hierarchies, plus filter out auto-generated conversations from listings.

## Context
When agents spawn child conversations (e.g., for sub-tasks), users had no way to navigate or view these related conversations. This made it difficult to track work distributed across multiple conversation threads. The conversation list was also cluttered with auto-generated conversations that users didn't initiate.

## Changes
- Added new `conversation-tree` command (`ct` alias) to interactively browse child conversations spawned by the current conversation and switch between them
- Added `--parent` flag to `select conversation` to filter the conversation picker to child conversations only
- Added `--parent` flag to `list conversation` to display child conversations in structured (porcelain) format
- Filtered out auto-generated conversations from list and show views, showing only user-initiated conversations by default
- Fixed cancelled todo status icon display
- Added shell plugin support for `conversation-tree` action via `:conversation-tree` alias

### Key Implementation Details
- `user_initiated_conversations()` filters conversations to only those where `initiator == "user"` and excludes conversations that are `related_conversation_ids` of other conversations (intermediate nodes)
- The `conversation-tree` command validates the parent exists, fetches children, presents an interactive selector, and switches the active conversation on selection
- `list conversation --parent <id>` outputs child conversations in a structured table with title and relative time ago

## Use Cases
- Navigate conversation hierarchies after an agent spawns child tasks
- Quickly switch between related conversations in a tree
- Get a clean, user-initiated-only conversation list without auto-generated noise
- Shell users can use `:conversation-tree` to browse child conversations inline

## Testing
```bash
# Build and run
cargo build

# List user-initiated conversations (filtered)
forge list conversation

# Show child conversations of current conversation
forge list conversation --parent <conversation-id>

# Interactively browse and switch child conversations
forge conversation-tree
# or
forge ct

# Via shell plugin
:conversation-tree
```

## Links
- Related issues: N/A
