### PR TITLE
fix(provider): sync fireworks-ai models with current serverless catalog

### DIFF
--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -3531,10 +3531,80 @@
     "auth_methods": ["api_key"],
     "models": [
       {
-        "id": "accounts/fireworks/models/kimi-k2p5",
-        "name": "Kimi K2.5",
-        "description": "Kimi K2.5 model",
-        "context_length": 256000,
+        "id": "accounts/fireworks/models/glm-5p2",
+        "name": "GLM 5.2",
+        "description": "GLM 5.2 model",
+        "context_length": 1048576,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "accounts/fireworks/models/glm-5p1",
+        "name": "GLM 5.1",
+        "description": "GLM 5.1 model",
+        "context_length": 202800,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "accounts/fireworks/routers/glm-5p1-fast",
+        "name": "GLM 5.1 Fast",
+        "description": "GLM 5.1 Fast model",
+        "context_length": 202800,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "accounts/fireworks/models/qwen3p7-plus",
+        "name": "Qwen 3.7 Plus",
+        "description": "Qwen 3.7 Plus model",
+        "context_length": 262144,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "accounts/fireworks/models/minimax-m3",
+        "name": "MiniMax-M3",
+        "description": "MiniMax-M3 model",
+        "context_length": 512000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "accounts/fireworks/models/minimax-m2p7",
+        "name": "MiniMax-M2.7",
+        "description": "MiniMax-M2.7 model",
+        "context_length": 196608,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "accounts/fireworks/models/kimi-k2p7-code",
+        "name": "Kimi K2.7 Code",
+        "description": "Kimi K2.7 Code model",
+        "context_length": 262144,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "accounts/fireworks/routers/kimi-k2p7-code-fast",
+        "name": "Kimi K2.7 Code Fast",
+        "description": "Kimi K2.7 Code Fast model",
+        "context_length": 262144,
         "tools_supported": true,
         "supports_parallel_tool_calls": true,
         "supports_reasoning": true,
@@ -3551,108 +3621,29 @@
         "input_modalities": ["text", "image"]
       },
       {
-        "id": "accounts/fireworks/models/kimi-k2-instruct",
-        "name": "Kimi K2 Instruct",
-        "description": "Kimi K2 Instruct model",
-        "context_length": 128000,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "accounts/fireworks/models/kimi-k2-thinking",
-        "name": "Kimi K2 Thinking",
-        "description": "Kimi K2 Thinking model",
-        "context_length": 256000,
+        "id": "accounts/fireworks/routers/kimi-k2p6-turbo",
+        "name": "Kimi K2.6 Turbo",
+        "description": "Kimi K2.6 Turbo model",
+        "context_length": 262144,
         "tools_supported": true,
         "supports_parallel_tool_calls": true,
         "supports_reasoning": true,
-        "input_modalities": ["text"]
+        "input_modalities": ["text", "image"]
       },
       {
-        "id": "accounts/fireworks/models/deepseek-v3p1",
-        "name": "DeepSeek V3.1",
-        "description": "DeepSeek V3.1 model",
-        "context_length": 163840,
+        "id": "accounts/fireworks/routers/kimi-k2p6-fast",
+        "name": "Kimi K2.6 Fast",
+        "description": "Kimi K2.6 Fast model",
+        "context_length": 262144,
         "tools_supported": true,
         "supports_parallel_tool_calls": true,
         "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "accounts/fireworks/models/minimax-m2p1",
-        "name": "MiniMax-M2.1",
-        "description": "MiniMax-M2.1 model",
-        "context_length": 200000,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "accounts/fireworks/models/minimax-m2p5",
-        "name": "MiniMax-M2.5",
-        "description": "MiniMax-M2.5 model",
-        "context_length": 196608,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
+        "input_modalities": ["text", "image"]
       },
       {
         "id": "accounts/fireworks/models/gpt-oss-120b",
         "name": "GPT OSS 120B",
         "description": "GPT OSS 120B model",
-        "context_length": 131072,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "accounts/fireworks/models/glm-4p7",
-        "name": "GLM 4.7",
-        "description": "GLM 4.7 model",
-        "context_length": 198000,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "accounts/fireworks/models/deepseek-v3p2",
-        "name": "DeepSeek V3.2",
-        "description": "DeepSeek V3.2 model",
-        "context_length": 160000,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "accounts/fireworks/models/glm-4p5",
-        "name": "GLM 4.5",
-        "description": "GLM 4.5 model",
-        "context_length": 131072,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "accounts/fireworks/models/glm-5",
-        "name": "GLM 5",
-        "description": "GLM 5 model",
-        "context_length": 202752,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "accounts/fireworks/models/glm-4p5-air",
-        "name": "GLM 4.5 Air",
-        "description": "GLM 4.5 Air model",
         "context_length": 131072,
         "tools_supported": true,
         "supports_parallel_tool_calls": true,
@@ -3670,16 +3661,6 @@
         "input_modalities": ["text"]
       },
       {
-        "id": "accounts/fireworks/models/deepseek-v4-flash",
-        "name": "DeepSeek V4 Flash",
-        "description": "DeepSeek V4 Flash model",
-        "context_length": 1000000,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
         "id": "accounts/fireworks/models/deepseek-v4-pro",
         "name": "DeepSeek V4 Pro",
         "description": "DeepSeek V4 Pro model",
@@ -3690,64 +3671,14 @@
         "input_modalities": ["text"]
       },
       {
-        "id": "accounts/fireworks/models/glm-5p1",
-        "name": "GLM 5.1",
-        "description": "GLM 5.1 model",
-        "context_length": 202800,
+        "id": "accounts/fireworks/models/deepseek-v4-flash",
+        "name": "DeepSeek V4 Flash",
+        "description": "DeepSeek V4 Flash model",
+        "context_length": 1000000,
         "tools_supported": true,
         "supports_parallel_tool_calls": true,
         "supports_reasoning": true,
         "input_modalities": ["text"]
-      },
-      {
-        "id": "accounts/fireworks/models/glm-5p2",
-        "name": "GLM 5.2",
-        "description": "GLM 5.2 model",
-        "context_length": 1048576,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "accounts/fireworks/models/kimi-k2p7-code",
-        "name": "Kimi K2.7 Code",
-        "description": "Kimi K2.7 Code model",
-        "context_length": 262000,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text", "image"]
-      },
-      {
-        "id": "accounts/fireworks/models/minimax-m2p7",
-        "name": "MiniMax-M2.7",
-        "description": "MiniMax-M2.7 model",
-        "context_length": 196608,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "accounts/fireworks/models/minimax-m3",
-        "name": "MiniMax-M3",
-        "description": "MiniMax-M3 model",
-        "context_length": 512000,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "accounts/fireworks/models/qwen3p7-plus",
-        "name": "Qwen 3.7 Plus",
-        "description": "Qwen 3.7 Plus model",
-        "context_length": 262144,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text", "image"]
       }
     ]
   },

--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -3531,109 +3531,9 @@
     "auth_methods": ["api_key"],
     "models": [
       {
-        "id": "accounts/fireworks/models/glm-5p2",
-        "name": "GLM 5.2",
-        "description": "GLM 5.2 model",
-        "context_length": 1048576,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "accounts/fireworks/models/glm-5p1",
-        "name": "GLM 5.1",
-        "description": "GLM 5.1 model",
-        "context_length": 202800,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "accounts/fireworks/routers/glm-5p1-fast",
-        "name": "GLM 5.1 Fast",
-        "description": "GLM 5.1 Fast model",
-        "context_length": 202800,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "accounts/fireworks/models/qwen3p7-plus",
-        "name": "Qwen 3.7 Plus",
-        "description": "Qwen 3.7 Plus model",
-        "context_length": 262144,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text", "image"]
-      },
-      {
-        "id": "accounts/fireworks/models/minimax-m3",
-        "name": "MiniMax-M3",
-        "description": "MiniMax-M3 model",
-        "context_length": 512000,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "accounts/fireworks/models/minimax-m2p7",
-        "name": "MiniMax-M2.7",
-        "description": "MiniMax-M2.7 model",
-        "context_length": 196608,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text"]
-      },
-      {
-        "id": "accounts/fireworks/models/kimi-k2p7-code",
-        "name": "Kimi K2.7 Code",
-        "description": "Kimi K2.7 Code model",
-        "context_length": 262144,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text", "image"]
-      },
-      {
-        "id": "accounts/fireworks/routers/kimi-k2p7-code-fast",
-        "name": "Kimi K2.7 Code Fast",
-        "description": "Kimi K2.7 Code Fast model",
-        "context_length": 262144,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text", "image"]
-      },
-      {
         "id": "accounts/fireworks/models/kimi-k2p6",
         "name": "Kimi K2.6",
         "description": "Kimi K2.6 model",
-        "context_length": 262144,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text", "image"]
-      },
-      {
-        "id": "accounts/fireworks/routers/kimi-k2p6-turbo",
-        "name": "Kimi K2.6 Turbo",
-        "description": "Kimi K2.6 Turbo model",
-        "context_length": 262144,
-        "tools_supported": true,
-        "supports_parallel_tool_calls": true,
-        "supports_reasoning": true,
-        "input_modalities": ["text", "image"]
-      },
-      {
-        "id": "accounts/fireworks/routers/kimi-k2p6-fast",
-        "name": "Kimi K2.6 Fast",
-        "description": "Kimi K2.6 Fast model",
         "context_length": 262144,
         "tools_supported": true,
         "supports_parallel_tool_calls": true,
@@ -3661,6 +3561,16 @@
         "input_modalities": ["text"]
       },
       {
+        "id": "accounts/fireworks/models/deepseek-v4-flash",
+        "name": "DeepSeek V4 Flash",
+        "description": "DeepSeek V4 Flash model",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
         "id": "accounts/fireworks/models/deepseek-v4-pro",
         "name": "DeepSeek V4 Pro",
         "description": "DeepSeek V4 Pro model",
@@ -3671,14 +3581,104 @@
         "input_modalities": ["text"]
       },
       {
-        "id": "accounts/fireworks/models/deepseek-v4-flash",
-        "name": "DeepSeek V4 Flash",
-        "description": "DeepSeek V4 Flash model",
-        "context_length": 1000000,
+        "id": "accounts/fireworks/models/glm-5p1",
+        "name": "GLM 5.1",
+        "description": "GLM 5.1 model",
+        "context_length": 202800,
         "tools_supported": true,
         "supports_parallel_tool_calls": true,
         "supports_reasoning": true,
         "input_modalities": ["text"]
+      },
+      {
+        "id": "accounts/fireworks/models/glm-5p2",
+        "name": "GLM 5.2",
+        "description": "GLM 5.2 model",
+        "context_length": 1048576,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "accounts/fireworks/models/kimi-k2p7-code",
+        "name": "Kimi K2.7 Code",
+        "description": "Kimi K2.7 Code model",
+        "context_length": 262144,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "accounts/fireworks/models/minimax-m2p7",
+        "name": "MiniMax-M2.7",
+        "description": "MiniMax-M2.7 model",
+        "context_length": 196608,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "accounts/fireworks/models/minimax-m3",
+        "name": "MiniMax-M3",
+        "description": "MiniMax-M3 model",
+        "context_length": 512000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "accounts/fireworks/models/qwen3p7-plus",
+        "name": "Qwen 3.7 Plus",
+        "description": "Qwen 3.7 Plus model",
+        "context_length": 262144,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "accounts/fireworks/routers/glm-5p1-fast",
+        "name": "GLM 5.1 Fast",
+        "description": "GLM 5.1 Fast model",
+        "context_length": 202800,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "accounts/fireworks/routers/kimi-k2p7-code-fast",
+        "name": "Kimi K2.7 Code Fast",
+        "description": "Kimi K2.7 Code Fast model",
+        "context_length": 262144,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "accounts/fireworks/routers/kimi-k2p6-turbo",
+        "name": "Kimi K2.6 Turbo",
+        "description": "Kimi K2.6 Turbo model",
+        "context_length": 262144,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "accounts/fireworks/routers/kimi-k2p6-fast",
+        "name": "Kimi K2.6 Fast",
+        "description": "Kimi K2.6 Fast model",
+        "context_length": 262144,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
       }
     ]
   },


### PR DESCRIPTION
Remove 11 deprecated models no longer available from the Fireworks API:
- kimi-k2p5, kimi-k2-instruct, kimi-k2-thinking
- deepseek-v3p1, deepseek-v3p2
- minimax-m2p1, minimax-m2p5
- glm-4p5, glm-4p5-air, glm-4p7, glm-5

Add 4 new router models:
- routers/glm-5p1-fast
- routers/kimi-k2p7-code-fast
- routers/kimi-k2p6-turbo
- routers/kimi-k2p6-fast

Normalize all kimi model context lengths to 262144 (256k).

Models confirmed against https://docs.fireworks.ai/serverless/pricing