### PR TITLE
chore:  Claude Sonnet 5 to all providers

### DIFF
--- a/crates/forge_app/src/dto/anthropic/response.rs
+++ b/crates/forge_app/src/dto/anthropic/response.rs
@@ -84,6 +84,11 @@ fn get_context_length(model_id: &str) -> Option<u64> {
         return Some(1_000_000);
     }
 
+    // Claude Sonnet 5 (1M context)
+    if model_id.starts_with("claude-sonnet-5") {
+        return Some(1_000_000);
+    }
+
     // Current models (200K context)
     if model_id.starts_with("claude-sonnet-4-5-")
         || model_id.starts_with("claude-haiku-4-5-")

--- a/crates/forge_app/src/transformers/model_specific_reasoning.rs
+++ b/crates/forge_app/src/transformers/model_specific_reasoning.rs
@@ -40,6 +40,7 @@ impl ModelSpecificReasoning {
             AnthropicModelFamily::AdaptiveOnly
         } else if id.contains("opus-4-6")
             || id.contains("46-opus")
+            || id.contains("sonnet-5")
             || id.contains("sonnet-4-6")
             || id.contains("46-sonnet")
         {

--- a/crates/forge_repo/src/provider/anthropic.rs
+++ b/crates/forge_repo/src/provider/anthropic.rs
@@ -92,9 +92,9 @@ impl<H: HttpInfra> Anthropic<H> {
 }
 
 /// Returns false when the model auto-enables interleaved thinking through
-/// adaptive thinking (Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5, Sonnet 4.6). When the model
-/// is unknown (e.g., listing endpoints), the flag is included because it is
-/// harmless on non-chat endpoints and necessary on older chat models.
+/// adaptive thinking (Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5, Sonnet 4.6). When
+/// the model is unknown (e.g., listing endpoints), the flag is included because
+/// it is harmless on non-chat endpoints and necessary on older chat models.
 fn interleaved_thinking_required(model: Option<&ModelId>) -> bool {
     let Some(model) = model else { return true };
     let id = model.as_str().to_lowercase();

--- a/crates/forge_repo/src/provider/anthropic.rs
+++ b/crates/forge_repo/src/provider/anthropic.rs
@@ -92,7 +92,7 @@ impl<H: HttpInfra> Anthropic<H> {
 }
 
 /// Returns false when the model auto-enables interleaved thinking through
-/// adaptive thinking (Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6). When the model
+/// adaptive thinking (Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5, Sonnet 4.6). When the model
 /// is unknown (e.g., listing endpoints), the flag is included because it is
 /// harmless on non-chat endpoints and necessary on older chat models.
 fn interleaved_thinking_required(model: Option<&ModelId>) -> bool {

--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -665,6 +665,16 @@
         "input_modalities": ["text", "image"]
       },
       {
+        "id": "claude-sonnet-5",
+        "name": "Claude Sonnet 5",
+        "description": "The best combination of speed and intelligence",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
         "id": "claude-sonnet-4-6",
         "name": "Claude Sonnet 4.6",
         "description": "Most balanced model for building agents and coding",
@@ -1452,6 +1462,46 @@
         "supports_parallel_tool_calls": true,
         "supports_reasoning": true,
         "input_modalities": ["text"]
+      },
+      {
+        "id": "global.anthropic.claude-sonnet-5",
+        "name": "Claude Sonnet 5 (Global)",
+        "description": "The best combination of speed and intelligence",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "us.anthropic.claude-sonnet-5",
+        "name": "Claude Sonnet 5 (US)",
+        "description": "The best combination of speed and intelligence",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "eu.anthropic.claude-sonnet-5",
+        "name": "Claude Sonnet 5 (EU)",
+        "description": "The best combination of speed and intelligence",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "anthropic.claude-sonnet-5",
+        "name": "Claude Sonnet 5",
+        "description": "The best combination of speed and intelligence",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
       },
       {
         "id": "global.anthropic.claude-sonnet-4-6",
@@ -2306,6 +2356,16 @@
         "input_modalities": ["text", "image"]
       },
       {
+        "id": "claude-sonnet-5",
+        "name": "Claude Sonnet 5",
+        "description": "The best combination of speed and intelligence",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
         "id": "claude-sonnet-4-6",
         "name": "Claude Sonnet 4.6",
         "description": "Most balanced Claude model with excellent performance and speed",
@@ -2842,6 +2902,16 @@
         "name": "Claude Opus 4.1",
         "description": "Powerful Claude model for complex tasks",
         "context_length": 200000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "claude-sonnet-5",
+        "name": "Claude Sonnet 5",
+        "description": "The best combination of speed and intelligence",
+        "context_length": 1000000,
         "tools_supported": true,
         "supports_parallel_tool_calls": true,
         "supports_reasoning": true,


### PR DESCRIPTION
## Summary
Adds **Claude Sonnet 5** (`claude-sonnet-5`) to all providers that hardcode a Claude model catalog, per the [models overview docs](https://platform.claude.com/docs/en/about-claude/models/overview.md).

Sonnet 5 has a 1M-token context window, 128k max output, supports adaptive thinking (always on), tools, and vision.

## Changes
**`crates/forge_repo/src/provider/provider.json`** — added `claude-sonnet-5`:
- `claude_code`, `vertex_ai_anthropic`, `opencode_zen` → `claude-sonnet-5`
- `bedrock` → all four ID variants matching the existing Sonnet 4.6 pattern: `global.`, `us.`, `eu.`, and `anthropic.claude-sonnet-5`

Providers that fetch models dynamically from a `/models` URL (e.g. `anthropic`, `open_router`, `requesty`) pick up Sonnet 5 automatically.

## Supporting logic
- `forge_repo/.../anthropic.rs` — excluded `sonnet-5` from the legacy `interleaved-thinking` beta header (auto-enabled via adaptive thinking).
- `forge_app/.../model_specific_reasoning.rs` — classified `sonnet-5` in the `AdaptiveFriendly` family (same as Sonnet 4.6).
- `forge_app/.../dto/anthropic/response.rs` — set context length to 1M tokens for `claude-sonnet-5`.

## Verification
- JSON validated
- `cargo check -p forge_app -p forge_repo` passes