### PR TITLE
fix(provider): meta muse spark 1.1 provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,21 @@ ORCAROUTER_API_KEY=<your_orcarouter_api_key>
 </details>
 
 <details>
+<summary><strong>Meta</strong></summary>
+
+```bash
+# .env
+MODEL_API_KEY=<your_meta_model_api_key>
+```
+
+```yaml
+# forge.yaml
+model: muse-spark-1.1
+```
+
+</details>
+
+<details>
 <summary><strong>IO Intelligence</strong></summary>
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ ORCAROUTER_API_KEY=<your_orcarouter_api_key>
 
 ```bash
 # .env
-MODEL_API_KEY=<your_meta_model_api_key>
+META_API_KEY=<your_meta_model_api_key>
 ```
 
 ```yaml

--- a/crates/forge_domain/src/provider.rs
+++ b/crates/forge_domain/src/provider.rs
@@ -84,6 +84,7 @@ impl ProviderId {
     pub const AMBIENT: ProviderId = ProviderId(Cow::Borrowed("ambient"));
     pub const NEURALWATT: ProviderId = ProviderId(Cow::Borrowed("neuralwatt"));
     pub const ORCA_ROUTER: ProviderId = ProviderId(Cow::Borrowed("orca_router"));
+    pub const META: ProviderId = ProviderId(Cow::Borrowed("meta"));
 
     /// Returns all built-in provider IDs
     ///
@@ -127,6 +128,7 @@ impl ProviderId {
             ProviderId::AMBIENT,
             ProviderId::NEURALWATT,
             ProviderId::ORCA_ROUTER,
+            ProviderId::META,
         ]
     }
 
@@ -164,6 +166,7 @@ impl ProviderId {
             "ambient" => "Ambient".to_string(),
             "neuralwatt" => "Neuralwatt".to_string(),
             "orca_router" => "OrcaRouter".to_string(),
+            "meta" => "Meta".to_string(),
             _ => {
                 // For other providers, use UpperCamelCase conversion
                 use convert_case::{Case, Casing};
@@ -222,6 +225,7 @@ impl std::str::FromStr for ProviderId {
             "ambient" => ProviderId::AMBIENT,
             "neuralwatt" => ProviderId::NEURALWATT,
             "orca_router" => ProviderId::ORCA_ROUTER,
+            "meta" => ProviderId::META,
             // For custom providers, use Cow::Owned to avoid memory leaks
             custom => ProviderId(Cow::Owned(custom.to_string())),
         };
@@ -600,6 +604,7 @@ mod tests {
         assert_eq!(ProviderId::NVIDIA.to_string(), "NVIDIA");
         assert_eq!(ProviderId::AMBIENT.to_string(), "Ambient");
         assert_eq!(ProviderId::ORCA_ROUTER.to_string(), "OrcaRouter");
+        assert_eq!(ProviderId::META.to_string(), "Meta");
     }
 
     #[test]
@@ -642,6 +647,7 @@ mod tests {
         assert!(built_in.contains(&ProviderId::NVIDIA));
         assert!(built_in.contains(&ProviderId::AMBIENT));
         assert!(built_in.contains(&ProviderId::ORCA_ROUTER));
+        assert!(built_in.contains(&ProviderId::META));
     }
 
     #[test]
@@ -757,6 +763,24 @@ mod tests {
     fn test_orca_router_in_built_in_providers() {
         let built_in = ProviderId::built_in_providers();
         assert!(built_in.contains(&ProviderId::ORCA_ROUTER));
+    }
+
+    #[test]
+    fn test_meta_from_str() {
+        let actual = ProviderId::from_str("meta").unwrap();
+        let expected = ProviderId::META;
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_meta_display_name() {
+        assert_eq!(ProviderId::META.to_string(), "Meta");
+    }
+
+    #[test]
+    fn test_meta_in_built_in_providers() {
+        let built_in = ProviderId::built_in_providers();
+        assert!(built_in.contains(&ProviderId::META));
     }
 
     #[test]

--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -4097,5 +4097,25 @@
     "url": "https://api.orcarouter.ai/v1/chat/completions",
     "models": "https://api.orcarouter.ai/v1/models",
     "auth_methods": ["api_key"]
+  },
+  {
+    "id": "meta",
+    "api_key_vars": "MODEL_API_KEY",
+    "url_param_vars": [],
+    "response_type": "OpenAIResponses",
+    "url": "https://api.meta.ai/v1/responses",
+    "models": [
+      {
+        "id": "muse-spark-1.1",
+        "name": "Muse Spark 1.1",
+        "description": "Meta's multimodal model for agentic tool calling, coding, structured output, image and video understanding, and long-context reasoning",
+        "context_length": 1048576,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      }
+    ],
+    "auth_methods": ["api_key"]
   }
 ]

--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -4100,7 +4100,7 @@
   },
   {
     "id": "meta",
-    "api_key_vars": "MODEL_API_KEY",
+    "api_key_vars": "META_API_KEY",
     "url_param_vars": [],
     "response_type": "OpenAIResponses",
     "url": "https://api.meta.ai/v1/responses",

--- a/crates/forge_repo/src/provider/provider_repo.rs
+++ b/crates/forge_repo/src/provider/provider_repo.rs
@@ -958,6 +958,59 @@ mod tests {
     }
 
     #[test]
+    fn test_meta_config() {
+        let configs = get_provider_configs();
+        let config = configs
+            .iter()
+            .find(|c| c.id == ProviderId::META)
+            .unwrap();
+        assert_eq!(config.id, ProviderId::META);
+        assert_eq!(config.api_key_vars, Some("MODEL_API_KEY".to_string()));
+        assert!(config.url_param_vars.is_empty());
+        assert_eq!(
+            config.response_type,
+            Some(ProviderResponse::OpenAIResponses)
+        );
+        assert_eq!(config.url.as_str(), "https://api.meta.ai/v1/responses");
+
+        match config.models.as_ref().expect("models should be present") {
+            Models::Hardcoded(models) => {
+                let model = models
+                    .iter()
+                    .find(|m| m.id.as_str() == "muse-spark-1.1")
+                    .expect("muse-spark-1.1 should be present in hardcoded models");
+                assert_eq!(
+                    model.context_length,
+                    Some(1048576),
+                    "muse-spark-1.1 should have 1048576 context length"
+                );
+                assert_eq!(
+                    model.tools_supported,
+                    Some(true),
+                    "muse-spark-1.1 should support tools"
+                );
+                assert_eq!(
+                    model.supports_parallel_tool_calls,
+                    Some(true),
+                    "muse-spark-1.1 should support parallel tool calls"
+                );
+                assert_eq!(
+                    model.supports_reasoning,
+                    Some(true),
+                    "muse-spark-1.1 should support reasoning"
+                );
+                assert!(
+                    model
+                        .input_modalities
+                        .contains(&forge_app::domain::InputModality::Image),
+                    "muse-spark-1.1 should support image input"
+                );
+            }
+            other => panic!("expected hardcoded models, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_provider_entry_with_static_models_converts_to_hardcoded() {
         let model = forge_domain::Model::new("Qwen3.6-35B-A3b-q3-mlx")
             .name("Qwen3.5-35B".to_string())

--- a/crates/forge_repo/src/provider/provider_repo.rs
+++ b/crates/forge_repo/src/provider/provider_repo.rs
@@ -960,10 +960,7 @@ mod tests {
     #[test]
     fn test_meta_config() {
         let configs = get_provider_configs();
-        let config = configs
-            .iter()
-            .find(|c| c.id == ProviderId::META)
-            .unwrap();
+        let config = configs.iter().find(|c| c.id == ProviderId::META).unwrap();
         assert_eq!(config.id, ProviderId::META);
         assert_eq!(config.api_key_vars, Some("MODEL_API_KEY".to_string()));
         assert!(config.url_param_vars.is_empty());

--- a/crates/forge_repo/src/provider/provider_repo.rs
+++ b/crates/forge_repo/src/provider/provider_repo.rs
@@ -962,7 +962,7 @@ mod tests {
         let configs = get_provider_configs();
         let config = configs.iter().find(|c| c.id == ProviderId::META).unwrap();
         assert_eq!(config.id, ProviderId::META);
-        assert_eq!(config.api_key_vars, Some("MODEL_API_KEY".to_string()));
+        assert_eq!(config.api_key_vars, Some("META_API_KEY".to_string()));
         assert!(config.url_param_vars.is_empty());
         assert_eq!(
             config.response_type,


### PR DESCRIPTION
## Summary

Add Meta as a new built-in provider to ForgeCode, using the Meta Model API at `https://api.meta.ai/v1`. Meta's API is OpenAI Responses-compatible with Bearer token authentication via `META_API_KEY`.

## Context

Meta recently launched their Model API with Muse Spark 1.1, a multimodal model supporting agentic tool calling, coding, structured output, image/video understanding, and long-context reasoning with a 1M-token context window. The API is drop-in compatible with the OpenAI Responses API, making this a pure configuration-driven integration with no new behavioral code needed.

## Changes

- **`crates/forge_repo/src/provider/provider.json`**: Add `meta` provider entry with `OpenAIResponses` response type, `MODEL_API_KEY` env var, and hardcoded `muse-spark-1.1` model (1,048,576 context, tools + parallel tools + reasoning, text + image input)
- **`crates/forge_domain/src/provider.rs`**: Register `META` constant, add to `built_in_providers()`, add `from_str()` and `display_name()` match arms, add 3 new tests + update 2 existing tests
- **`crates/forge_repo/src/provider/provider_repo.rs`**: Add `test_meta_config` test verifying provider config, response type, URL, and hardcoded model specs
- **`README.md`**: Add Meta env var documentation entry

## Testing

- `cargo check` passes with no errors
- `cargo test -p forge_domain -- provider::tests` — 42 passed, 0 failed (including 3 new Meta tests)
- `cargo test -p forge_repo -- provider_repo::tests` — 14 passed, 0 failed (including `test_meta_config`)
- `cargo insta test --accept` — no snapshot changes needed

## Notes

- Uses `OpenAIResponses` response type per Meta's recommendation for "the full feature set for agentic workflows" including reasoning replay across turns
- The `InputModality` enum only supports `Text` and `Image` — the Meta API also accepts video and PDF inputs, but these cannot be represented in the current domain model
- Follows the Vivgrid precedent (`OpenAIResponses` + hardcoded models) and the Neuralwatt precedent (hardcoded model content verification)

Co-Authored-By: ForgeCode <noreply@forgecode.dev>