### PR TITLE
test: add marker file to verify sdk tool pr redirect

### DIFF
--- a/.sdk-tool-pr-test
+++ b/.sdk-tool-pr-test
@@ -1,0 +1,1 @@
+SDK tool PR redirect test 1784194989


### PR DESCRIPTION
## Summary
Add a `.sdk-tool-pr-test` marker file containing a unique identifier to verify the SDK tool's PR redirect behaviour end-to-end.

## Testing
Confirm the PR is created and redirected as expected by the SDK tool; the file carries a unique token (`1784194989`) to identify this test run.