### PR TITLE
fix: strip null enum values unconditionally in enforce_strict_schema

### DIFF
--- a/crates/forge_app/src/utils.rs
+++ b/crates/forge_app/src/utils.rs
@@ -522,6 +522,18 @@ pub fn enforce_strict_schema(schema: &mut serde_json::Value, strict_mode: bool) 
 
             normalize_array_items(map, strict_mode);
 
+            // A `null` literal inside a typed `enum` array (produced by
+            // schemars' AddNullable transform for Option<Enum> fields) is a
+            // non-standard representation that several OpenAI-compatible
+            // providers reject. For example, Moonshot AI (kimi) returns:
+            //   "enum value (<nil>) does not match any type in [string]".
+            // Strip null entries from enum arrays unconditionally so the
+            // schema is valid regardless of whether strict mode is applied
+            // (e.g. when kimi is routed through OpenRouter).
+            if let Some(serde_json::Value::Array(enum_values)) = map.get_mut("enum") {
+                enum_values.retain(|v| !v.is_null());
+            }
+
             if strict_mode
                 && map
                     .get("nullable")
@@ -529,10 +541,6 @@ pub fn enforce_strict_schema(schema: &mut serde_json::Value, strict_mode: bool) 
                     .unwrap_or(false)
             {
                 map.remove("nullable");
-
-                if let Some(serde_json::Value::Array(enum_values)) = map.get_mut("enum") {
-                    enum_values.retain(|v| !v.is_null());
-                }
 
                 let description = map.remove("description");
                 let non_null_branch = serde_json::Value::Object(std::mem::take(map));
@@ -1323,6 +1331,36 @@ mod tests {
         enforce_strict_schema(&mut schema, false);
 
         // In non-strict mode, nullable should be preserved as-is
+        assert_eq!(schema["properties"]["output_mode"]["nullable"], json!(true));
+        assert!(schema["properties"]["output_mode"].get("anyOf").is_none());
+    }
+
+    #[test]
+    fn test_null_enum_values_stripped_in_non_strict_mode() {
+        // schemars' AddNullable transform appends `null` to enum arrays for
+        // Option<Enum> fields. Several OpenAI-compatible providers (e.g.
+        // Moonshot/kimi via OpenRouter) reject a null literal inside a typed
+        // enum array. Null entries must be stripped even in non-strict mode so
+        // the schema is valid regardless of the provider routing.
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "output_mode": {
+                    "nullable": true,
+                    "type": "string",
+                    "enum": ["content", "files_with_matches", "count", null]
+                }
+            }
+        });
+
+        enforce_strict_schema(&mut schema, false);
+
+        // The null entry is removed, but nullable is preserved (non-strict mode
+        // does not convert to anyOf).
+        assert_eq!(
+            schema["properties"]["output_mode"]["enum"],
+            json!(["content", "files_with_matches", "count"])
+        );
         assert_eq!(schema["properties"]["output_mode"]["nullable"], json!(true));
         assert!(schema["properties"]["output_mode"].get("anyOf").is_none());
     }


### PR DESCRIPTION
## Summary

Fixes #3767

When `kimi-k3` is routed through **OpenRouter**, every request fails with a `400 Bad Request` because the tool schema contains an invalid `null` value inside the `output_mode` enum array, which Moonshot AI rejects:

```
Invalid request: tools.function.parameters is not a valid moonshot flavored json schema,
details: <At path 'properties.output_mode.enum': enum value (<nil>) does not match any type in [string]>
```

## Root Cause

1. `ToolCatalog::schema` (`crates/forge_domain/src/tools/catalog.rs:893`) applies schemars' `AddNullable` transform, which appends `null` to enum arrays for `Option<Enum>` fields.
2. `enforce_strict_schema` (`crates/forge_app/src/utils.rs`) only stripped those null entries **inside the `strict_mode` branch**.
3. The `EnforceStrictToolSchema` transformer (`crates/forge_app/src/dto/openai/transformers/pipeline.rs:102-112`) is only enabled for the direct `MOONSHOT` / `KIMI_CODING` provider IDs — **not** for `OPEN_ROUTER`. So when kimi is accessed via OpenRouter, the null enum value survives and is sent to Moonshot, which rejects it.

## Fix (Approach B)

Hoist the null-stripping logic out of the `strict_mode` branch so it runs **unconditionally**. The `anyOf` conversion (and `nullable` removal) remains strict-mode-only.

This makes the non-strict path safe for **all** OpenAI-compatible providers, not just the ones explicitly gated into strict mode. A `null` literal inside a typed `enum` array is a non-standard representation that multiple providers reject, so stripping it unconditionally is the more robust behavior.

## Changes

- `crates/forge_app/src/utils.rs`: moved the `enum_values.retain(|v| !v.is_null())` call to run before the `strict_mode`/`nullable` check.
- Added test `test_null_enum_values_stripped_in_non_strict_mode` verifying null is removed in non-strict mode while `nullable: true` is preserved.

## Test Plan

- [x] `cargo test -p forge_app --lib utils::tests` — 64 passed (including new test)
- [x] `cargo test -p forge_app --lib dto::openai::transformers` — 106 passed
- [x] `cargo test -p forge_repo --lib provider::openai_responses` — 139 passed (including catalog tool snapshot tests)
- [x] `cargo test -p forge_app` — full suite green

## Alternative Considered

**Approach A** (narrower) would add `|| when_model("kimi")(request)` to the `strict_schema` condition in `pipeline.rs`. That only fixes kimi specifically and leaves the latent issue for any other OpenAI-compatible provider that rejects null enum values. Approach B is broader and prevents the class of bug entirely.