### PR TITLE
fix(provider): add kimi-k3 and glm-5p2-fast to fireworks-ai

### DIFF
--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -3940,6 +3940,16 @@
     "auth_methods": ["api_key"],
     "models": [
       {
+        "id": "accounts/fireworks/models/kimi-k3",
+        "name": "Kimi K3",
+        "description": "Moonshot AI Kimi K3 flagship model with 2.8T parameters, 1M-token context, native vision, always-on reasoning, and tool calling capabilities",
+        "context_length": 1048576,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
         "id": "accounts/fireworks/models/kimi-k2p6",
         "name": "Kimi K2.6",
         "description": "Kimi K2.6 model",
@@ -4054,6 +4064,16 @@
         "name": "GLM 5.1 Fast",
         "description": "GLM 5.1 Fast model",
         "context_length": 202800,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "accounts/fireworks/routers/glm-5p2-fast",
+        "name": "GLM 5.2 Fast",
+        "description": "GLM 5.2 Fast model",
+        "context_length": 1048576,
         "tools_supported": true,
         "supports_parallel_tool_calls": true,
         "supports_reasoning": true,

--- a/crates/forge_repo/src/provider/provider_repo.rs
+++ b/crates/forge_repo/src/provider/provider_repo.rs
@@ -1063,6 +1063,49 @@ mod tests {
     }
 
     #[test]
+    fn test_fireworks_ai_config() {
+        use std::str::FromStr;
+
+        let configs = get_provider_configs();
+        let fireworks_id = ProviderId::from_str("fireworks-ai").unwrap();
+        let config = configs.iter().find(|c| c.id == fireworks_id).unwrap();
+        assert_eq!(
+            config.api_key_vars,
+            Some("FIREWORKS_AI_API_KEY".to_string())
+        );
+        assert_eq!(config.response_type, Some(ProviderResponse::OpenAI));
+        assert_eq!(
+            config.url.as_str(),
+            "https://api.fireworks.ai/inference/v1/chat/completions"
+        );
+        // Fireworks' /models endpoint needs an API key and omits capability
+        // metadata, so the serverless catalog is hardcoded using full
+        // deployment IDs.
+        match config.models.as_ref().expect("models should be present") {
+            Models::Hardcoded(models) => {
+                let kimi_k3 = models
+                    .iter()
+                    .find(|m| m.id.as_str() == "accounts/fireworks/models/kimi-k3")
+                    .expect("expected kimi-k3 to be present in hardcoded models");
+                assert_eq!(kimi_k3.context_length, Some(1048576));
+                assert!(
+                    kimi_k3
+                        .input_modalities
+                        .contains(&forge_app::domain::InputModality::Image),
+                    "kimi-k3 should support image input"
+                );
+                assert!(
+                    models
+                        .iter()
+                        .any(|m| m.id.as_str() == "accounts/fireworks/routers/glm-5p2-fast"),
+                    "expected glm-5p2-fast router to be present in hardcoded models"
+                );
+            }
+            other => panic!("expected hardcoded models, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_provider_entry_with_static_models_converts_to_hardcoded() {
         let model = forge_domain::Model::new("Qwen3.6-35B-A3b-q3-mlx")
             .name("Qwen3.5-35B".to_string())


### PR DESCRIPTION
## What

Adds two models missing from the hardcoded `fireworks-ai` serverless catalog:

| id | name | context | modalities |
| --- | --- | --- | --- |
| `accounts/fireworks/models/kimi-k3` | Kimi K3 | 1,048,576 | text, image |
| `accounts/fireworks/routers/glm-5p2-fast` | GLM 5.2 Fast | 1,048,576 | text |

## Why

Both are live on Fireworks serverless but unreachable from Forge today, because
`fireworks-ai` pins a hardcoded model list rather than fetching `/models`.

- **Kimi K3** — Moonshot's 2.8T-parameter flagship, 1M context, native vision,
  tool calling. Forge already ships it for `moonshot`, `kimi_coding`,
  `opencode_zen` and `opencode_go` (#3707), so Fireworks was the remaining gap.
  Source: https://fireworks.ai/models/fireworks/kimi-k3
- **GLM 5.2 Fast** — speculative-decoding router for the already-listed
  `glm-5p2`, same quality at ~140 tok/s. Matches the existing pattern of
  carrying `-fast`/`-turbo` routers alongside their base models
  (`glm-5p1-fast`, `kimi-k2p6-fast`, `kimi-k2p7-code-fast`).
  Source: https://fireworks.ai/blog/glm-5p2-fast

The `kimi-k3` entry is not speculative: I have been running it as my daily
driver against Fireworks via a local `provider.json` override
(`provider_id = "fireworks-ai"`, `model_id = "accounts/fireworks/models/kimi-k3"`),
so the deployment id, context length, tool calling and image input are all
confirmed working. This PR just moves that override upstream.

## Notes for review

- `kimi-k3` reuses the exact `description` and `context_length` (1,048,576)
  already used by the `moonshot`, `kimi_coding`, `opencode_zen` and
  `opencode_go` entries for this model, rather than the terser
  `"<Name> model"` style used elsewhere in the Fireworks block. Consistency
  across kimi-k3 entries seemed more useful than consistency within the block —
  happy to shorten it if you prefer.
- `glm-5p2-fast` is marked text-only, mirroring the `glm-5p2` base entry.
- **No `ProviderPipeline` change.** `fireworks-ai` is not in the strict-tool-
  schema set and its existing Kimi deployments (`kimi-k2p6`, `kimi-k2p7-code`)
  work without it; K3 has been working for me the same way.
- **Deliberately not included:** `accounts/fireworks/routers/kimi-k3-fast`. The
  Fire Pass docs reference it, but I could not confirm the id is live, so
  `fireworks-ai-firepass` is left untouched. Worth a follow-up once confirmed.
- **Not included:** `qwen3p7-max` — the model page lists it as on-demand
  deployment only, not serverless.

## Testing

- Added `test_fireworks_ai_config` in `provider_repo.rs` — the provider had no
  test coverage at all. Asserts the api-key var, response type, URL, and that
  both new entries are present with K3's context length and image modality.
  Verified the assertions fail when the expected values are wrong.
- `cargo test -p forge_repo provider::` → 284 passed, 0 failed
- `cargo +nightly fmt --all -- --check` → clean
- `cargo clippy -p forge_repo --all-targets` → clean
- Live: K3 exercised daily through `fireworks-ai` with the equivalent local
  provider override.
