### PR TITLE
feat: support Gemini 3.6 Flash, 3.5 Flash-Lite, and 3.5 Flash Cyber

### DIFF
--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -1398,6 +1398,36 @@
     "url": "https://{{#if (eq LOCATION \"global\")}}aiplatform.googleapis.com{{else}}{{LOCATION}}-aiplatform.googleapis.com{{/if}}/v1beta1/projects/{{PROJECT_ID}}/locations/{{LOCATION}}/publishers/google",
     "models": [
       {
+        "id": "gemini-3.6-flash",
+        "name": "Gemini 3.6 Flash",
+        "description": "Google's latest workhorse model, optimized for speed, cost, and native tool use",
+        "context_length": 1048576,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "gemini-3.5-flash-lite",
+        "name": "Gemini 3.5 Flash-Lite",
+        "description": "Google's fastest and most cost-efficient Gemini model, optimized for low latency use cases",
+        "context_length": 1048576,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "gemini-3.5-flash-cyber",
+        "name": "Gemini 3.5 Flash Cyber",
+        "description": "Google's narrow, security-focused variant of the Gemini 3.5 Flash model",
+        "context_length": 1048576,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
         "id": "gemini-3.5-flash",
         "name": "Gemini 3.5 Flash",
         "description": "",
@@ -2776,6 +2806,36 @@
     "response_type": "Google",
     "url": "https://generativelanguage.googleapis.com/v1beta",
     "models": [
+      {
+        "id": "gemini-3.6-flash",
+        "name": "Gemini 3.6 Flash",
+        "description": "Google's latest workhorse model, optimized for speed, cost, and native tool use",
+        "context_length": 1048576,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "gemini-3.5-flash-lite",
+        "name": "Gemini 3.5 Flash-Lite",
+        "description": "Google's fastest and most cost-efficient Gemini model, optimized for low latency use cases",
+        "context_length": 1048576,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "gemini-3.5-flash-cyber",
+        "name": "Gemini 3.5 Flash Cyber",
+        "description": "Google's narrow, security-focused variant of the Gemini 3.5 Flash model",
+        "context_length": 1048576,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
       {
         "id": "gemini-3.5-flash",
         "name": "Gemini 3.5 Flash",

--- a/vertex.json
+++ b/vertex.json
@@ -1,5 +1,35 @@
 [
   {
+    "id": "google/gemini-3.6-flash",
+    "name": "Gemini 3.6 Flash",
+    "description": "Google's latest workhorse model, optimized for speed, cost, and native tool use",
+    "context_length": 1048576,
+    "tools_supported": true,
+    "supports_parallel_tool_calls": true,
+    "supports_reasoning": true,
+    "input_modalities": ["text", "image"]
+  },
+  {
+    "id": "google/gemini-3.5-flash-lite",
+    "name": "Gemini 3.5 Flash-Lite",
+    "description": "Google's fastest and most cost-efficient Gemini model, optimized for low latency use cases",
+    "context_length": 1048576,
+    "tools_supported": true,
+    "supports_parallel_tool_calls": true,
+    "supports_reasoning": true,
+    "input_modalities": ["text", "image"]
+  },
+  {
+    "id": "google/gemini-3.5-flash-cyber",
+    "name": "Gemini 3.5 Flash Cyber",
+    "description": "Google's narrow, security-focused variant of the Gemini 3.5 Flash model",
+    "context_length": 1048576,
+    "tools_supported": true,
+    "supports_parallel_tool_calls": true,
+    "supports_reasoning": true,
+    "input_modalities": ["text", "image"]
+  },
+  {
     "id": "google/gemini-3.5-flash",
     "name": "Gemini 3.5 Flash",
     "description": "",


### PR DESCRIPTION
## Summary
Add support for Gemini 3.6 Flash, 3.5 Flash-Lite, and 3.5 Flash Cyber models.

## Context
Google recently released the Gemini 3.6 Flash, 3.5 Flash-Lite, and 3.5 Flash Cyber models on July 21, 2026. This PR adds support for these models to Forge, enabling users to run fast, cost-efficient, and highly capable agentic workflows.

## Changes
- Added `gemini-3.6-flash`, `gemini-3.5-flash-lite`, and `gemini-3.5-flash-cyber` to the `vertex_ai` provider list in `crates/forge_repo/src/provider/provider.json`.
- Added `gemini-3.6-flash`, `gemini-3.5-flash-lite`, and `gemini-3.5-flash-cyber` to the `google_ai_studio` provider list in `crates/forge_repo/src/provider/provider.json`.
- Added `google/gemini-3.6-flash`, `google/gemini-3.5-flash-lite`, and `google/gemini-3.5-flash-cyber` to the root `vertex.json` file.

## Use Cases
- Run multi-step agentic workflows with 1M context window at extremely low latency and cost.
- Select these models interactively via the `:model` command.

## Testing
- Verified compilation and ran tests in the `forge_repo` and `forge_app` crates:
```bash
cargo check
cargo test -p forge_repo
cargo test -p forge_app
```

## Links
Fix #3779
