### PR TITLE
fix(provider): Alibaba Token Plan provider

### DIFF
--- a/crates/forge_domain/src/provider.rs
+++ b/crates/forge_domain/src/provider.rs
@@ -87,6 +87,7 @@ impl ProviderId {
     pub const META: ProviderId = ProviderId(Cow::Borrowed("meta"));
     pub const KIMI_CODING: ProviderId = ProviderId(Cow::Borrowed("kimi_coding"));
     pub const MOONSHOT: ProviderId = ProviderId(Cow::Borrowed("moonshot"));
+    pub const ALIBABA_TOKEN_PLAN: ProviderId = ProviderId(Cow::Borrowed("alibaba_token_plan"));
 
     /// Returns all built-in provider IDs
     ///
@@ -133,6 +134,7 @@ impl ProviderId {
             ProviderId::META,
             ProviderId::KIMI_CODING,
             ProviderId::MOONSHOT,
+            ProviderId::ALIBABA_TOKEN_PLAN,
         ]
     }
 
@@ -232,6 +234,7 @@ impl std::str::FromStr for ProviderId {
             "meta" => ProviderId::META,
             "kimi_coding" => ProviderId::KIMI_CODING,
             "moonshot" => ProviderId::MOONSHOT,
+            "alibaba_token_plan" => ProviderId::ALIBABA_TOKEN_PLAN,
             // For custom providers, use Cow::Owned to avoid memory leaks
             custom => ProviderId(Cow::Owned(custom.to_string())),
         };
@@ -813,6 +816,26 @@ mod tests {
     fn test_kimi_coding_from_str_roundtrip() {
         let actual = ProviderId::from_str("kimi_coding").unwrap();
         let expected = ProviderId::KIMI_CODING;
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_alibaba_token_plan_display_name() {
+        let actual = ProviderId::ALIBABA_TOKEN_PLAN.to_string();
+        let expected = "AlibabaTokenPlan".to_string();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_alibaba_token_plan_in_built_in_providers() {
+        let built_in = ProviderId::built_in_providers();
+        assert!(built_in.contains(&ProviderId::ALIBABA_TOKEN_PLAN));
+    }
+
+    #[test]
+    fn test_alibaba_token_plan_from_str_roundtrip() {
+        let actual = ProviderId::from_str("alibaba_token_plan").unwrap();
+        let expected = ProviderId::ALIBABA_TOKEN_PLAN;
         assert_eq!(actual, expected);
     }
 

--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -3864,6 +3864,166 @@
     "auth_methods": ["api_key"]
   },
   {
+    "id": "alibaba_token_plan",
+    "api_key_vars": "ALIBABA_TOKEN_PLAN_API_KEY",
+    "url_param_vars": [],
+    "response_type": "OpenAI",
+    "url": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions",
+    "models": [
+      {
+        "id": "qwen3.8-max-preview",
+        "name": "Qwen3.8 Max Preview",
+        "description": "Alibaba's flagship Qwen3.8 Max preview model with 1M context, multimodal input, reasoning, and tool calling capabilities",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "qwen3.7-max",
+        "name": "Qwen3.7 Max",
+        "description": "Alibaba's Qwen3.7 Max model with 1M context, reasoning, and tool calling capabilities",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "qwen3.7-plus",
+        "name": "Qwen3.7 Plus",
+        "description": "Alibaba's Qwen3.7 Plus model with 1M context, multimodal input, reasoning, and tool calling capabilities",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "qwen3.6-plus",
+        "name": "Qwen3.6 Plus",
+        "description": "Alibaba's Qwen3.6 Plus model with 1M context, multimodal input, reasoning, and tool calling capabilities",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "qwen3.6-flash",
+        "name": "Qwen3.6 Flash",
+        "description": "Alibaba's fast and economical Qwen3.6 Flash model with 1M context, multimodal input, reasoning, and tool calling capabilities",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "deepseek-v4-pro",
+        "name": "DeepSeek V4 Pro",
+        "description": "DeepSeek V4 Pro model with 1M context, reasoning, and tool calling capabilities",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "deepseek-v4-flash",
+        "name": "DeepSeek V4 Flash",
+        "description": "Fast DeepSeek V4 lane for economical reasoning, coding, and long-context work",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "deepseek-v3.2",
+        "name": "DeepSeek V3.2",
+        "description": "DeepSeek V3.2 model with reasoning and tool calling capabilities",
+        "context_length": 131072,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "kimi-k2.7-code",
+        "name": "Kimi K2.7 Code",
+        "description": "Moonshot AI Kimi K2.7 Code model with 256K context, multimodal input, reasoning, and tool calling capabilities",
+        "context_length": 262144,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "kimi-k2.6",
+        "name": "Kimi K2.6",
+        "description": "Moonshot AI Kimi K2.6 model with multimodal input, reasoning, and tool calling capabilities",
+        "context_length": 262144,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "kimi-k2.5",
+        "name": "Kimi K2.5",
+        "description": "Moonshot AI Kimi K2.5 model with multimodal input, reasoning, and tool calling capabilities",
+        "context_length": 262144,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "glm-5.2",
+        "name": "GLM-5.2",
+        "description": "Zhipu AI GLM-5.2 flagship model with 1M context, reasoning, and tool calling capabilities",
+        "context_length": 1000000,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "glm-5.1",
+        "name": "GLM-5.1",
+        "description": "Zhipu AI GLM-5.1 model with 200K context, reasoning, and tool calling capabilities",
+        "context_length": 202752,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "glm-5",
+        "name": "GLM-5",
+        "description": "Zhipu AI GLM-5 model with 200K context, reasoning, and tool calling capabilities",
+        "context_length": 202752,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "MiniMax-M2.5",
+        "name": "MiniMax M2.5",
+        "description": "MiniMax M2.5 model with reasoning and tool calling capabilities",
+        "context_length": 196608,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      }
+    ],
+    "auth_methods": ["api_key"]
+  },
+  {
     "id": "novita",
     "api_key_vars": "NOVITA_API_KEY",
     "url_param_vars": [],

--- a/crates/forge_repo/src/provider/provider.json
+++ b/crates/forge_repo/src/provider/provider.json
@@ -989,6 +989,16 @@
         "input_modalities": ["text", "image"]
       },
       {
+        "id": "kimi-k2.7-code-flex",
+        "name": "Kimi K2.7 Code Flex",
+        "description": "Kimi K2.7 Code on the flex tier — lower-cost serving with relaxed latency guarantees.",
+        "context_length": 262144,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
         "id": "kimi-k2.6",
         "name": "Kimi K2.6",
         "description": "Kimi K2.6 — quant-agnostic canonical name for the Kimi K2.6 family.",
@@ -1002,6 +1012,36 @@
         "id": "kimi-k2.6-fast",
         "name": "Kimi K2.6 Fast",
         "description": "Moonshot Kimi K2.6 with thinking mode disabled for instant, lower-latency responses.",
+        "context_length": 262128,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": false,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "kimi-k2.6-flex",
+        "name": "Kimi K2.6 Flex",
+        "description": "Kimi K2.6 on the flex tier — lower-cost serving with relaxed latency guarantees.",
+        "context_length": 262128,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "kimi-k2.5",
+        "name": "Kimi K2.5",
+        "description": "Kimi K2.5 — quant-agnostic canonical name for the Kimi K2.5 family.",
+        "context_length": 262128,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text", "image"]
+      },
+      {
+        "id": "kimi-k2.5-fast",
+        "name": "Kimi K2.5 Fast",
+        "description": "Moonshot Kimi K2.5 with thinking mode disabled for instant, lower-latency responses.",
         "context_length": 262128,
         "tools_supported": true,
         "supports_parallel_tool_calls": true,
@@ -1049,6 +1089,16 @@
         "input_modalities": ["text"]
       },
       {
+        "id": "glm-5.2-flex",
+        "name": "GLM-5.2 Flex",
+        "description": "GLM-5.2 on the flex tier — lower-cost serving with relaxed latency guarantees.",
+        "context_length": 1048560,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
         "id": "glm-5.2-short",
         "name": "GLM-5.2 (short)",
         "description": "GLM-5.2 with a 200K context window and a bounded reasoning budget — faster, lower-energy serving for everyday coding, agentic, and chat workloads under 200K tokens. Private preview (grant-gated).",
@@ -1062,6 +1112,26 @@
         "id": "glm-5.2-short-fast",
         "name": "GLM-5.2 (short, fast)",
         "description": "GLM-5.2 short with reasoning OFF — the fastest, lowest-energy variant of the 200K pool, for latency-sensitive coding, chat, and tool-use that does not need chain-of-thought. Private preview (grant-gated).",
+        "context_length": 199984,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": false,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "glm-5.2-short-flex",
+        "name": "GLM-5.2 (short, flex)",
+        "description": "GLM-5.2 short on the flex tier — lower-cost serving with relaxed latency guarantees for workloads under 200K tokens.",
+        "context_length": 199984,
+        "tools_supported": true,
+        "supports_parallel_tool_calls": true,
+        "supports_reasoning": true,
+        "input_modalities": ["text"]
+      },
+      {
+        "id": "glm-5.2-short-fast-flex",
+        "name": "GLM-5.2 (short, fast, flex)",
+        "description": "GLM-5.2 short with reasoning OFF on the flex tier — lowest-cost variant of the 200K pool with relaxed latency guarantees.",
         "context_length": 199984,
         "tools_supported": true,
         "supports_parallel_tool_calls": true,

--- a/crates/forge_repo/src/provider/provider_repo.rs
+++ b/crates/forge_repo/src/provider/provider_repo.rs
@@ -929,6 +929,14 @@ mod tests {
                     models.iter().any(|m| m.id.as_str() == "qwen3.5-397b"),
                     "expected qwen3.5-397b to be present in hardcoded models"
                 );
+                assert!(
+                    models.iter().any(|m| m.id.as_str() == "glm-5.2-flex"),
+                    "expected glm-5.2-flex to be present in hardcoded models"
+                );
+                assert!(
+                    models.iter().any(|m| m.id.as_str() == "kimi-k2.7-code-flex"),
+                    "expected kimi-k2.7-code-flex to be present in hardcoded models"
+                );
             }
             other => panic!("expected hardcoded models, got {other:?}"),
         }

--- a/crates/forge_repo/src/provider/provider_repo.rs
+++ b/crates/forge_repo/src/provider/provider_repo.rs
@@ -934,7 +934,9 @@ mod tests {
                     "expected glm-5.2-flex to be present in hardcoded models"
                 );
                 assert!(
-                    models.iter().any(|m| m.id.as_str() == "kimi-k2.7-code-flex"),
+                    models
+                        .iter()
+                        .any(|m| m.id.as_str() == "kimi-k2.7-code-flex"),
                     "expected kimi-k2.7-code-flex to be present in hardcoded models"
                 );
             }

--- a/crates/forge_repo/src/provider/provider_repo.rs
+++ b/crates/forge_repo/src/provider/provider_repo.rs
@@ -1008,6 +1008,38 @@ mod tests {
     }
 
     #[test]
+    fn test_alibaba_token_plan_config() {
+        let configs = get_provider_configs();
+        let config = configs
+            .iter()
+            .find(|c| c.id == ProviderId::ALIBABA_TOKEN_PLAN)
+            .unwrap();
+        assert_eq!(config.id, ProviderId::ALIBABA_TOKEN_PLAN);
+        assert_eq!(
+            config.api_key_vars,
+            Some("ALIBABA_TOKEN_PLAN_API_KEY".to_string())
+        );
+        assert!(config.url_param_vars.is_empty());
+        assert_eq!(config.response_type, Some(ProviderResponse::OpenAI));
+        assert_eq!(
+            config.url.as_str(),
+            "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions"
+        );
+        // Alibaba Token Plan exposes an OpenAI-compatible endpoint but no
+        // capability metadata via /models, so models are hardcoded in
+        // provider.json.
+        match config.models.as_ref().expect("models should be present") {
+            Models::Hardcoded(models) => {
+                assert!(
+                    models.iter().any(|m| m.id.as_str() == "qwen3.7-max"),
+                    "expected qwen3.7-max to be present in hardcoded models"
+                );
+            }
+            other => panic!("expected hardcoded models, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_moonshot_config() {
         let configs = get_provider_configs();
         let config = configs


### PR DESCRIPTION
## Summary

### Alibaba Token Plan
Adds support for the **Alibaba Token Plan** provider ([models.dev/providers/alibaba-token-plan](https://models.dev/providers/alibaba-token-plan/)), mirroring how opencode supports it.

- OpenAI-compatible endpoint: `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1`
- Auth via `ALIBABA_TOKEN_PLAN_API_KEY` (same env var as opencode)
- New `ProviderId::ALIBABA_TOKEN_PLAN` built-in constant with FromStr roundtrip support
- Models hardcoded in `provider.json` (endpoint does not expose capability metadata), covering the text/chat models: Qwen3.8 Max Preview, Qwen3.7 Max/Plus, Qwen3.6 Plus/Flash, DeepSeek V4 Pro/Flash, DeepSeek V3.2, Kimi K2.5/2.6/2.7 Code, GLM-5/5.1/5.2, MiniMax-M2.5 (image/video generation models excluded)

### Neuralwatt missing models
Fixes missing Neuralwatt models reported by a user ("what happened to flex models from neuralwatt? they have em on opencode"):
- Flex tier: `glm-5.2-flex`, `glm-5.2-short-flex`, `glm-5.2-short-fast-flex`, `kimi-k2.6-flex`, `kimi-k2.7-code-flex`
- Also adds `kimi-k2.5` and `kimi-k2.5-fast`, which were missing entirely

## Test plan

- Added `test_alibaba_token_plan_config` in `provider_repo.rs`
- Extended `test_neuralwatt_config` to assert flex models are present
- Added display-name, built-in-list, and FromStr roundtrip tests in `forge_domain/src/provider.rs`
- `cargo test -p forge_domain -p forge_repo` provider tests pass; provider.json validated as JSON

Co-Authored-By: ForgeCode <noreply@forgecode.dev>