### PR TITLE
fix: retry OpenAI server errors

### DIFF
--- a/crates/forge_repo/src/provider/retry.rs
+++ b/crates/forge_repo/src/provider/retry.rs
@@ -4,8 +4,14 @@ use forge_app::dto::openai::{Error, ErrorCode, ErrorResponse};
 use forge_config::RetryConfig;
 
 const TRANSPORT_ERROR_CODES: [&str; 3] = ["ERR_STREAM_PREMATURE_CLOSE", "ECONNRESET", "ETIMEDOUT"];
-const OPENAI_OVERLOADED_ERROR_CODE: &str = "server_is_overloaded";
+const OPENAI_RETRYABLE_ERROR_CODES: [&str; 2] = ["server_is_overloaded", "server_error"];
 
+/// Converts known transient provider failures into retryable domain errors.
+///
+/// # Arguments
+///
+/// * `error` - The provider error to classify.
+/// * `retry_config` - Configured retryable HTTP status codes.
 pub fn into_retry(error: anyhow::Error, retry_config: &RetryConfig) -> anyhow::Error {
     if let Some(code) = get_req_status_code(&error)
         .or(get_event_req_status_code(&error))
@@ -70,7 +76,7 @@ fn get_event_req_status_code(error: &anyhow::Error) -> Option<u16> {
 #[derive(Clone, Copy)]
 enum RetryableApiErrorCode {
     Transport,
-    OpenAIOverloaded,
+    OpenAIServer,
 }
 
 impl RetryableApiErrorCode {
@@ -81,7 +87,7 @@ impl RetryableApiErrorCode {
 
         match self {
             RetryableApiErrorCode::Transport => TRANSPORT_ERROR_CODES.contains(&code),
-            RetryableApiErrorCode::OpenAIOverloaded => code == OPENAI_OVERLOADED_ERROR_CODE,
+            RetryableApiErrorCode::OpenAIServer => OPENAI_RETRYABLE_ERROR_CODES.contains(&code),
         }
     }
 }
@@ -117,9 +123,7 @@ fn is_openai_overloaded_error(error: &anyhow::Error) -> bool {
     error
         .downcast_ref::<Error>()
         .is_some_and(|error| match error {
-            Error::Response(error) => {
-                has_error_code(error, RetryableApiErrorCode::OpenAIOverloaded)
-            }
+            Error::Response(error) => has_error_code(error, RetryableApiErrorCode::OpenAIServer),
             _ => false,
         })
 }
@@ -149,6 +153,7 @@ fn is_event_transport_error(error: &anyhow::Error) -> bool {
 mod tests {
     use anyhow::anyhow;
     use forge_app::dto::openai::{Error, ErrorCode, ErrorResponse};
+    use pretty_assertions::assert_eq;
 
     use super::*;
 
@@ -336,24 +341,26 @@ mod tests {
     }
 
     #[test]
-    fn test_openai_server_overloaded_error_is_retryable() {
-        let retry_config = fixture_retry_config(vec![]);
+    fn test_openai_server_errors_are_retryable() {
+        let fixture = fixture_retry_config(vec![]);
 
-        let error = anyhow::Error::from(Error::Response(
-            ErrorResponse::default()
-                .code(ErrorCode::String("server_is_overloaded".to_string()))
-                .message(
-                    "Our servers are currently overloaded. Please try again later.".to_string(),
-                ),
-        ));
+        for code in OPENAI_RETRYABLE_ERROR_CODES {
+            let error = anyhow::Error::from(Error::Response(
+                ErrorResponse::default().code(ErrorCode::String(code.to_string())),
+            ));
+            let actual = is_retryable(into_retry(error, &fixture));
+            let expected = true;
 
-        assert!(is_retryable(into_retry(error, &retry_config)));
+            assert_eq!(actual, expected, "{code} should be retryable");
+        }
 
         let error = anyhow::Error::from(Error::Response(
             ErrorResponse::default().code(ErrorCode::String("rate_limit".to_string())),
         ));
+        let actual = is_retryable(into_retry(error, &fixture));
+        let expected = false;
 
-        assert!(!is_retryable(into_retry(error, &retry_config)));
+        assert_eq!(actual, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- retry OpenAI `server_error` responses, alongside `server_is_overloaded`
- cover retryable OpenAI server error codes with regression tests

## Verification
- `cargo test -p forge_repo provider::retry::tests`
- `cargo insta test -p forge_repo --accept`
- `cargo clippy -p forge_repo --lib --tests -- -D warnings`

Closes #3782