### PR TITLE
fix: native Windows auto-update, PATH cap, and Ctrl+C terminal restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,6 +2696,7 @@ dependencies = [
  "nucleo-picker",
  "pretty_assertions",
  "rustyline",
+ "signal-hook 0.3.18",
  "tracing",
 ]
 

--- a/crates/forge_infra/src/executor.rs
+++ b/crates/forge_infra/src/executor.rs
@@ -54,6 +54,14 @@ impl ForgeCommandExecutorService {
         // Other common tools
         command.env("GREP_OPTIONS", "--color=always"); // GNU grep
 
+        // Windows cmd.exe stops resolving commands once PATH exceeds its
+        // ~2047-char batch limit. Pass a deduplicated, length-capped PATH so
+        // tools like `curl` still resolve even with a polluted PATH.
+        #[cfg(windows)]
+        if let Some(path) = sanitize_windows_path() {
+            command.env("PATH", path);
+        }
+
         let parameter = if is_windows { "/C" } else { "-c" };
         command.arg(parameter);
 
@@ -146,6 +154,59 @@ impl ForgeCommandExecutorService {
             exit_code: status.code(),
             command,
         })
+    }
+}
+
+/// Builds a sanitized PATH for child processes on Windows.
+///
+/// cmd.exe stops resolving commands once PATH exceeds its ~2047-char batch
+/// limit, so a PATH polluted with duplicates (e.g. the user PATH mirroring the
+/// whole system PATH) silently breaks every shell command. Deduplicate the
+/// entries, always keep the critical System directories first, and cap the
+/// total length so spawned cmd.exe instances can always resolve tools.
+#[cfg(windows)]
+fn sanitize_windows_path() -> Option<String> {
+    const MAX_PATH_LEN: usize = 1900;
+
+    let system_root = std::env::var_os("SystemRoot")
+        .unwrap_or_else(|| std::ffi::OsString::from("C:\\Windows"));
+    let mut seen = std::collections::HashSet::new();
+    let mut parts: Vec<String> = Vec::new();
+
+    // Always resolve these even if the caller's PATH is completely broken.
+    let critical = [
+        PathBuf::from(&system_root).join("System32"),
+        PathBuf::from(&system_root).join("System32").join("Wbem"),
+        PathBuf::from(&system_root)
+            .join("System32")
+            .join("WindowsPowerShell")
+            .join("v1.0"),
+    ];
+    for dir in critical {
+        let key = dir.to_string_lossy().to_lowercase();
+        if seen.insert(key) {
+            parts.push(dir.to_string_lossy().into_owned());
+        }
+    }
+
+    let mut total: usize = parts.iter().map(|p| p.len() + 1).sum();
+    for entry in std::env::split_paths(&std::env::var_os("PATH")?) {
+        let entry = entry.to_string_lossy();
+        let key = entry.to_lowercase();
+        if entry.is_empty() || !seen.insert(key) {
+            continue;
+        }
+        total += entry.len() + 1;
+        if total > MAX_PATH_LEN {
+            break;
+        }
+        parts.push(entry.into_owned());
+    }
+
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(";"))
     }
 }
 

--- a/crates/forge_main/src/update.rs
+++ b/crates/forge_main/src/update.rs
@@ -11,10 +11,13 @@ use update_informer::{Check, Version, registry};
 /// When `auto_update` is true, exits immediately after a successful update
 /// without prompting the user.
 async fn execute_update_command(api: Arc<impl API>, auto_update: bool) {
+    // The POSIX `curl … | sh` pipe cannot work on native Windows: there is no
+    // `sh`, and cmd.exe stops resolving commands once PATH exceeds its ~2047
+    // char batch limit. Use a native Windows updater there instead.
+    let command = update_command();
+
     // Spawn a new task that won't block the main application
-    let output = api
-        .execute_shell_command_raw("curl -fsSL https://forgecode.dev/cli | sh")
-        .await;
+    let output = api.execute_shell_command_raw(&command).await;
 
     match output {
         Err(err) => {
@@ -47,6 +50,93 @@ async fn execute_update_command(api: Arc<impl API>, auto_update: bool) {
             }
         }
     }
+}
+
+/// Returns the update command for the current platform.
+///
+/// On Windows this returns a PowerShell invocation that downloads the release
+/// binary and stages an atomic swap; on other platforms it returns the official
+/// `curl … | sh` one-liner.
+fn update_command() -> String {
+    #[cfg(windows)]
+    {
+        windows_update_command().unwrap_or_else(|| "exit 1".to_string())
+    }
+    #[cfg(not(windows))]
+    {
+        "curl -fsSL https://forgecode.dev/cli | sh".to_string()
+    }
+}
+
+/// Builds a native Windows update command.
+///
+/// The running `forge.exe` is locked while the process is alive, so the new
+/// binary cannot be replaced in place. Instead we:
+///
+/// 1. Download `forge-{arch}-pc-windows-msvc.exe` to `forge.exe.new` next to
+///    the current binary using PowerShell (absolute paths only, immune to the
+///    length-capped PATH that breaks `curl` resolution in cmd.exe).
+/// 2. Stage a small `.cmd` helper that waits for `forge.exe` to exit, swaps
+///    `forge.exe.new` over `forge.exe`, cleans up, and relaunches forge.
+/// 3. Launch that helper detached, so it survives forge exiting.
+#[cfg(windows)]
+fn windows_update_command() -> Option<String> {
+    use std::io::Write;
+
+    let local_app_data = std::env::var("LOCALAPPDATA").ok()?;
+    let install_dir = format!(r"{local_app_data}\Programs\Forge");
+    let new_exe = format!(r"{install_dir}\forge.exe.new");
+    let exe = format!(r"{install_dir}\forge.exe");
+    let swap_bat = format!(r"{install_dir}\_forge_swap.cmd");
+
+    // The wait loop uses full paths to tasklist/find/timeout so it keeps
+    // working even when the inherited PATH is polluted beyond cmd.exe's
+    // ~2047-char batch limit. move/del/start are cmd built-ins.
+    let swap_content = format!(
+        "@echo off\r\n\
+         set /a count=0\r\n\
+         :wait\r\n\
+         set /a count+=1\r\n\
+         if %count% gtr 900 goto abort\r\n\
+         %SystemRoot%\\System32\\tasklist.exe /FI \"IMAGENAME eq forge.exe\" 2>nul | %SystemRoot%\\System32\\find.exe /I \"forge.exe\" >nul\r\n\
+         if not errorlevel 1 (\r\n\
+           %SystemRoot%\\System32\\timeout.exe /t 1 /nobreak >nul\r\n\
+           goto wait\r\n\
+         )\r\n\
+         move /Y \"{new_exe}\" \"{exe}\"\r\n\
+         del \"%~f0\"\r\n\
+         start \"\" \"{exe}\"\r\n\
+         exit /b 0\r\n\
+         :abort\r\n\
+         del \"%~f0\"\r\n\
+         del \"{new_exe}\"\r\n\
+         exit /b 1\r\n"
+    );
+
+    std::fs::create_dir_all(&install_dir).ok()?;
+    let mut swap_file = std::fs::File::create(&swap_bat).ok()?;
+    swap_file.write_all(swap_content.as_bytes()).ok()?;
+
+    let ps_script = format!(
+        r#"$ErrorActionPreference = 'Stop'
+$dir = Join-Path $env:LOCALAPPDATA 'Programs\Forge'
+New-Item -ItemType Directory -Force -Path $dir | Out-Null
+$arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {{ 'aarch64' }} else {{ 'x86_64' }}
+$url = 'https://github.com/tailcallhq/forgecode/releases/latest/download/forge-' + $arch + '-pc-windows-msvc.exe'
+$new = Join-Path $dir 'forge.exe.new'
+Invoke-WebRequest -Uri $url -OutFile $new -UseBasicParsing
+$swap = Join-Path $dir '_forge_swap.cmd'
+Start-Process -FilePath $swap -WindowStyle Hidden
+"#
+    );
+
+    let ps_path = format!(r"{install_dir}\forge-update.ps1");
+    let mut ps_file = std::fs::File::create(&ps_path).ok()?;
+    ps_file.write_all(ps_script.as_bytes()).ok()?;
+
+    Some(format!(
+        r#"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass -File "{ps_path}""#
+    ))
 }
 
 async fn confirm_update(version: Version) -> bool {

--- a/crates/forge_select/Cargo.toml
+++ b/crates/forge_select/Cargo.toml
@@ -14,6 +14,7 @@ derive_setters.workspace = true
 nucleo.workspace = true
 nucleo-picker.workspace = true
 rustyline.workspace = true
+signal-hook = "0.3"
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/forge_select/src/preview.rs
+++ b/crates/forge_select/src/preview.rs
@@ -1,11 +1,13 @@
 use std::collections::BTreeSet;
 use std::io::{self, Write};
 use std::process::{Command, Stdio};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use std::{cmp, fmt};
 
 use bstr::ByteSlice;
+use signal_hook::consts::SIGINT;
 use crossterm::cursor::{Hide, MoveTo, MoveToColumn, MoveUp, Show};
 use crossterm::event::{
     self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
@@ -286,6 +288,26 @@ pub fn run_select_ui(options: SelectUiOptions) -> anyhow::Result<Option<String>>
     Ok(run_select_ui_values(options)?.and_then(|values| values.into_iter().next()))
 }
 
+/// Process-wide SIGINT flag used as a terminal-restore safety net.
+///
+/// When a real SIGINT arrives while the picker is not blocked in the key event
+/// reader (e.g. forge is spawned in its own process group and Ctrl+C delivers
+/// an actual signal rather than a raw-mode key event), the flag is set. The
+/// picker loop notices it and restores the terminal before returning, instead
+/// of letting the process be killed with raw mode still enabled — which would
+/// leave the shell with broken, half-echoed input.
+static SIGINT_FLAG: OnceLock<Arc<AtomicBool>> = OnceLock::new();
+
+fn sigint_flag() -> &'static Arc<AtomicBool> {
+    SIGINT_FLAG.get_or_init(|| {
+        let flag = Arc::new(AtomicBool::new(false));
+        // Register once for the process lifetime. Errors (e.g. an unsupported
+        // platform) are ignored so the picker still works without the net.
+        let _ = signal_hook::flag::register(SIGINT, Arc::clone(&flag));
+        flag
+    })
+}
+
 fn run_select_ui_values(options: SelectUiOptions) -> anyhow::Result<Option<Vec<String>>> {
     let SelectUiOptions {
         prompt,
@@ -322,6 +344,9 @@ fn run_select_ui_values(options: SelectUiOptions) -> anyhow::Result<Option<Vec<S
     let _ = matcher.tick(50);
 
     let guard = TerminalGuard::enter()?;
+    // Reset the SIGINT safety-net flag so a stale signal from a previous picker
+    // invocation can't abort this one spuriously.
+    sigint_flag().store(false, Ordering::SeqCst);
     let mut stderr = io::BufWriter::new(io::stderr());
     let prompt = prompt.unwrap_or_else(|| "❯ ".to_string());
     let preview_command = preview.unwrap_or_default();
@@ -431,6 +456,14 @@ fn run_select_ui_values(options: SelectUiOptions) -> anyhow::Result<Option<Vec<S
                 },
             )?;
             needs_render = false;
+        }
+
+        // Safety net: if a real SIGINT arrived while we weren't reading keys,
+        // restore the terminal and exit cleanly instead of dying in raw mode.
+        if sigint_flag().load(Ordering::Relaxed) {
+            restore_select_viewport(&mut stderr, reserved_height, viewport_top_row)?;
+            drop(guard);
+            return Ok(None);
         }
 
         if event::poll(Duration::from_millis(250))? {

--- a/shell-plugin/lib/dispatcher.zsh
+++ b/shell-plugin/lib/dispatcher.zsh
@@ -90,6 +90,18 @@ function _forge_action_default() {
 function forge-accept-line() {
     # Save the original command for history
     local original_buffer="$BUFFER"
+
+    # Belt-and-suspenders: if a stray SIGINT ever reaches the widget itself
+    # (e.g. when job control is unavailable), restore a sane ZLE state instead
+    # of leaving the buffer/cursor desynced. Child processes reset trapped
+    # signals to their default disposition, so forge still sees a normal
+    # Ctrl+C — this trap only protects the widget shell itself.
+    # LOCAL_TRAPS makes the trap function-scoped, so it is automatically
+    # restored on every exit path (including the early returns below for
+    # editor/commit-preview/suggest) instead of leaking to the main prompt.
+    setopt LOCAL_OPTIONS LOCAL_TRAPS
+    local _forge_int_trap='BUFFER=""; CURSOR=0; zle -I; zle reset-prompt'
+    trap "$_forge_int_trap" INT
     
     # Parse the buffer first in parent shell context to avoid subshell issues
     local user_action=""
@@ -270,10 +282,11 @@ function forge-accept-line() {
     local action_status=$?
     _forge_osc133_emit "D;$action_status"
     _forge_osc133_emit "A"
-    
+
     # Centralized reset after all actions complete
     # This ensures consistent prompt state without requiring each action to call _forge_reset
     # Exceptions: editor, commit-preview, and suggest actions return early as they intentionally modify BUFFER
     _forge_reset
+    trap - INT
     return $action_status
 }

--- a/shell-plugin/lib/helpers.zsh
+++ b/shell-plugin/lib/helpers.zsh
@@ -74,7 +74,34 @@ function _forge_exec_interactive() {
     [[ -n "$_FORGE_SESSION_MODEL" ]] && local -x FORGE_SESSION__MODEL_ID="$_FORGE_SESSION_MODEL"
     [[ -n "$_FORGE_SESSION_PROVIDER" ]] && local -x FORGE_SESSION__PROVIDER_ID="$_FORGE_SESSION_PROVIDER"
     [[ -n "$_FORGE_SESSION_REASONING_EFFORT" ]] && local -x FORGE_REASONING__EFFORT="$_FORGE_SESSION_REASONING_EFFORT"
-    "${cmd[@]}" </dev/tty >/dev/tty
+
+    # Run forge in its own process group so Ctrl+C (SIGINT) targets forge
+    # ONLY, never the ZLE widget that launched it. ZLE widgets run with the
+    # child in zsh's own foreground process group: a plain foreground call
+    # means Ctrl+C interrupts both zsh and forge. The widget aborts before
+    # _forge_reset runs, and forge's raw-mode terminal restoration never
+    # executes on SIGINT — leaving the terminal corrupted (broken echo,
+    # mis-timed input bursts, ghost prompts that come and go).
+    #
+    # Job control (MONITOR) makes `&` create a new process group, and `fg`
+    # makes it the terminal's foreground group. zsh simply waits while forge
+    # owns the terminal — the same isolation vim/fzf get. `zle -I` is
+    # required before job-control operations from inside a widget.
+    if [[ -n "${WIDGET:-}" ]]; then
+        zle -I
+    fi
+    setopt LOCAL_OPTIONS
+    if setopt MONITOR 2>/dev/null; then
+        "${cmd[@]}" </dev/tty >/dev/tty &
+        # `fg` should succeed in an interactive shell with job control;
+        # if it ever fails, still wait for forge to finish so the widget
+        # never returns while forge keeps owning the terminal.
+        fg 2>/dev/null || wait $!
+    else
+        # Non-interactive shell (no job control): fall back to a plain
+        # foreground execution.
+        "${cmd[@]}" </dev/tty >/dev/tty
+    fi
 }
 
 function _forge_select() {


### PR DESCRIPTION
## Summary
Fix the Windows auto-updater (which breaks on native Windows with `'curl' is not recognized`), and stop Ctrl+C from corrupting interactive forge sessions launched from the zsh plugin.

## Context
Two independent problems were found and traced to root cause:

1. **Windows auto-update fails on native Windows.** The updater ran `cmd.exe /C curl -fsSL https://forgecode.dev/cli | sh`. On native Windows there is no `sh`, and `cmd.exe` silently stops resolving *any* command once `PATH` exceeds its ~2047-char batch limit — a very common state because the user `PATH` frequently mirrors the entire system `PATH` (a 9,772-char effective PATH reproduced the exact `'curl' is not recognized` error). PowerShell resolves the same PATH fine, which is why it "worked elsewhere."

2. **Ctrl+C in zsh corrupts the session.** `:prompt` runs forge's interactive TUI as a child of a ZLE widget in zsh's own foreground process group (job control is off during widgets). Ctrl+C therefore SIGINTs both zsh and forge. zsh's widget aborts before `_forge_reset` runs, and forge has no signal handler anywhere, so its raw-mode terminal restoration (`TerminalGuard::drop`) never executes on SIGINT — leaving raw mode enabled, which produces broken half-echoed input, mis-timed key bursts, and ghost prompts that come and go.

## Changes
- **`crates/forge_main/src/update.rs`** — platform-branched updater. Windows now uses a native PowerShell command (absolute `powershell.exe` path, immune to a polluted PATH) that downloads `forge-{arch}-pc-windows-msvc.exe` from the GitHub release and stages an atomic swap via a detached `.cmd` helper (waits for `forge.exe` to exit, swaps `forge.exe.new` over it, cleans up, relaunches). Non-Windows keeps the official `curl … | sh` one-liner.
- **`crates/forge_infra/src/executor.rs`** — Windows child processes get a sanitized PATH: critical dirs (`System32`, `Wbem`, PowerShell `v1.0`) first, deduplicated entries, capped at 1900 chars so spawned `cmd.exe` can always resolve tools.
- **`crates/forge_select/src/preview.rs`** (+ `signal-hook` dep) — a process-wide SIGINT safety-net flag is registered once; the picker loop checks it and restores the viewport/terminal before returning cleanly instead of dying in raw mode. Coexists with the existing `tokio::signal::ctrl_c()` handling in the main UI.
- **`shell-plugin/lib/helpers.zsh`** — `_forge_exec_interactive` now enables job control locally (`setopt LOCAL_OPTIONS MONITOR`), launches forge in its own process group, and `fg`s it, so Ctrl+C targets forge only — the same isolation vim/fzf get. Falls back to plain foreground execution when job control is unavailable.
- **`shell-plugin/lib/dispatcher.zsh`** — `forge-accept-line` installs a function-scoped INT trap (`setopt LOCAL_OPTIONS LOCAL_TRAPS`) that restores ZLE state as belt-and-suspenders; it is automatically cleared on every exit path, including the editor/commit-preview/suggest early returns.

### Key Implementation Details
- The Windows updater cannot replace `forge.exe` in place (the running process locks it), so the new binary is downloaded to `forge.exe.new` and swapped by a detached helper that outlives forge. The helper uses full paths to `tasklist`/`find`/`timeout` so it works even when the inherited PATH is broken.
- The SIGINT flag is a `OnceLock<Arc<AtomicBool>>` registered once per process; the picker's 250 ms poll notices the flag and restores the terminal. Ctrl+C inside the picker is still handled as a raw-mode key event; the flag only covers real signals arriving outside the key reader (e.g. when forge runs in its own process group).

## Use Cases
- `forge` users on native Windows with a long/duplicated `PATH` can actually update (previously: silent failure or `'curl' is not recognized`).
- macOS/Unix users who run `:prompt` in zsh can press Ctrl+C without losing their terminal state or corrupting subsequent input.

## Testing
```bash
# Rust side
cargo check -p forge_select -p forge_infra -p forge_main
cargo test -p forge_main --lib update::

# zsh plugin (from shell-plugin/)
zsh -n lib/helpers.zsh
zsh -n lib/dispatcher.zsh

# Manual: Windows updater path
#   set PATH to >2047 chars (or a PATH that duplicates system entries), run
#   `forge update` and confirm PowerShell download + swap helper run.
# Manual: zsh Ctrl+C
#   in an interactive zsh with the plugin loaded, run `:prompt`, press Ctrl+C,
#   and confirm the prompt/input remain intact with no stray characters.
```

## Links
- Original report: native Windows auto-update fails (`curl` not recognized); Ctrl+C in zsh leaves broken/corrupted input
