### PR TITLE
ci: make rustfmt policy stable-compatible

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,6 +1,1 @@
-unstable_features = true
 struct_lit_width = 60
-imports_granularity = "Module"
-group_imports = "StdExternalCrate"
-wrap_comments = true
-comment_width = 80

--- a/crates/forge_main/src/info.rs
+++ b/crates/forge_main/src/info.rs
@@ -75,7 +75,7 @@ impl Section {
 /// # Output Format
 ///
 /// ```text
-/// 
+///
 /// CONFIGURATION
 ///   model gpt-4
 /// provider openai


### PR DESCRIPTION
## Summary
- remove nightly-only rustfmt options from the shared formatter policy
- normalize one existing rustdoc whitespace violation

## Recovery provenance
Reconstructed narrowly from historical branches `fix/stable-rustfmt-policy-adfa0978` and `fix/stable-rustfmt-policy-c2cd6fd` on current `origin/main`; original refs remain retained.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`

Co-Authored-By: ForgeCode <noreply@forgecode.dev>