### PR TITLE
fix: retry openai server errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2324,6 +2324,7 @@ dependencies = [
  "derive_setters",
  "gh-workflow",
  "indexmap 2.14.0",
+ "pretty_assertions",
  "serde",
  "serde_json",
 ]
@@ -2433,6 +2434,7 @@ dependencies = [
  "nom",
  "pin-project-lite",
  "pin-utils",
+ "pretty_assertions",
  "reqwest 0.12.28",
  "rocket",
  "thiserror 2.0.19",

--- a/crates/forge_ci/Cargo.toml
+++ b/crates/forge_ci/Cargo.toml
@@ -12,4 +12,5 @@ indexmap.workspace = true
 derive_setters.workspace = true
 
 [dev-dependencies]
+pretty_assertions.workspace = true
 

--- a/crates/forge_ci/src/release_matrix.rs
+++ b/crates/forge_ci/src/release_matrix.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 /// Matrix entry for build targets
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct MatrixEntry {
     pub os: &'static str,
     pub target: &'static str,
@@ -96,5 +96,202 @@ impl From<ReleaseMatrix> for Value {
         serde_json::json!({
             "include": value.entries()
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    /// Reusable fixture returning the default release matrix.
+    fn fixture() -> ReleaseMatrix {
+        ReleaseMatrix::default()
+    }
+
+    #[test]
+    fn test_default_matrix_entry_count() {
+        let actual = fixture().entries().len();
+
+        let expected = 9;
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_first_entry_is_linux_musl_cross_build() {
+        let fixture = fixture();
+
+        let actual = fixture
+            .entries()
+            .first()
+            .expect("Matrix should not be empty")
+            .clone();
+
+        let expected = MatrixEntry {
+            os: "ubuntu-latest",
+            target: "x86_64-unknown-linux-musl",
+            binary_name: "forge-x86_64-unknown-linux-musl",
+            binary_path: "target/x86_64-unknown-linux-musl/release/forge",
+            cross: "true",
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_targets_are_unique() {
+        let fixture = fixture();
+
+        let actual = {
+            let mut targets: Vec<&str> = fixture.entries().iter().map(|e| e.target).collect();
+            targets.sort_unstable();
+            targets.dedup();
+            targets.len()
+        };
+
+        let expected = fixture.entries().len();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_binary_name_matches_target_naming_convention() {
+        let fixture = fixture();
+
+        let actual: Vec<&str> = fixture
+            .entries()
+            .iter()
+            .filter(|e| !e.binary_name.starts_with(&format!("forge-{}", e.target)))
+            .map(|e| e.target)
+            .collect();
+
+        let expected: Vec<&str> = vec![];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_windows_entries_use_exe_extension() {
+        let fixture = fixture();
+
+        let actual: Vec<(&str, bool, bool)> = fixture
+            .entries()
+            .iter()
+            .filter(|e| e.target.contains("windows"))
+            .map(|e| {
+                (
+                    e.target,
+                    e.binary_name.ends_with(".exe"),
+                    e.binary_path.ends_with("forge.exe"),
+                )
+            })
+            .collect();
+
+        let expected = vec![
+            ("x86_64-pc-windows-msvc", true, true),
+            ("aarch64-pc-windows-msvc", true, true),
+        ];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_binary_path_is_release_profile_for_target() {
+        let fixture = fixture();
+
+        let actual: Vec<&str> = fixture
+            .entries()
+            .iter()
+            .filter(|e| {
+                !e.binary_path
+                    .starts_with(&format!("target/{}/release/", e.target))
+            })
+            .map(|e| e.target)
+            .collect();
+
+        let expected: Vec<&str> = vec![];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_cross_flag_is_boolean_string() {
+        let fixture = fixture();
+
+        let actual: Vec<&str> = fixture
+            .entries()
+            .iter()
+            .filter(|e| e.cross != "true" && e.cross != "false")
+            .map(|e| e.target)
+            .collect();
+
+        let expected: Vec<&str> = vec![];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_cross_compiled_targets() {
+        let fixture = fixture();
+
+        let actual: Vec<&str> = fixture
+            .entries()
+            .iter()
+            .filter(|e| e.cross == "true")
+            .map(|e| e.target)
+            .collect();
+
+        let expected = vec![
+            "x86_64-unknown-linux-musl",
+            "aarch64-unknown-linux-musl",
+            "aarch64-unknown-linux-gnu",
+            "aarch64-linux-android",
+        ];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_runner_os_matches_target_platform() {
+        let fixture = fixture();
+
+        let actual: Vec<(&str, &str)> = fixture
+            .entries()
+            .iter()
+            .map(|e| (e.target, e.os))
+            .filter(|(target, os)| {
+                let expected_os = if target.contains("apple") {
+                    "macos-latest"
+                } else if target.contains("windows") {
+                    "windows-latest"
+                } else {
+                    "ubuntu-latest"
+                };
+                *os != expected_os
+            })
+            .collect();
+
+        let expected: Vec<(&str, &str)> = vec![];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_into_value_wraps_entries_under_include_key() {
+        let fixture = fixture();
+
+        let actual = Value::from(fixture.clone());
+
+        let expected = serde_json::json!({ "include": fixture.entries() });
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_into_value_include_is_array_of_full_entries() {
+        let fixture = fixture();
+
+        let actual = Value::from(fixture)["include"][8].clone();
+
+        let expected = serde_json::json!({
+            "os": "ubuntu-latest",
+            "target": "aarch64-linux-android",
+            "binary_name": "forge-aarch64-linux-android",
+            "binary_path": "target/aarch64-linux-android/release/forge",
+            "cross": "true",
+        });
+        assert_eq!(actual, expected);
     }
 }

--- a/crates/forge_config/src/decimal.rs
+++ b/crates/forge_config/src/decimal.rs
@@ -92,3 +92,112 @@ impl<'de> serde::Deserialize<'de> for Decimal {
         Ok(Self(f64::deserialize(deserializer)?))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    /// Reusable fixture producing a `Decimal` from any `f64`.
+    fn fixture(value: f64) -> Decimal {
+        Decimal::from(value)
+    }
+
+    #[test]
+    fn test_value_returns_inner() {
+        let fixture = fixture(1.25);
+
+        let actual = fixture.value();
+
+        let expected = 1.25;
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_default_is_zero() {
+        let actual = Decimal::default();
+
+        let expected = fixture(0.0);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_from_f32_widens_to_f64() {
+        let actual = Decimal::from(0.5f32);
+
+        let expected = fixture(0.5);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_into_f64_roundtrip() {
+        let fixture = fixture(3.75);
+
+        let actual: f64 = fixture.into();
+
+        let expected = 3.75;
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_debug_delegates_to_inner_f64() {
+        let fixture = fixture(0.1);
+
+        let actual = format!("{fixture:?}");
+
+        let expected = format!("{:?}", 0.1f64);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_partial_ord_compares_by_inner_value() {
+        let setup = (fixture(0.1), fixture(0.2));
+
+        let actual = setup.0.partial_cmp(&setup.1);
+
+        let expected = Some(std::cmp::Ordering::Less);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_serialize_rounds_to_two_decimals() {
+        let fixture = fixture(0.100_000_001_490_116_12);
+
+        let actual = serde_json::to_string(&fixture).unwrap();
+
+        let expected = "0.1".to_string();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_serialize_rounds_half_away_from_zero() {
+        let fixture = fixture(1.567);
+
+        let actual = serde_json::to_string(&fixture).unwrap();
+
+        let expected = "1.57".to_string();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_deserialize_preserves_full_precision() {
+        let setup = "0.12345";
+
+        let actual: Decimal = serde_json::from_str(setup).unwrap();
+
+        let expected = fixture(0.12345);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_serialize_deserialize_roundtrip_is_rounded() {
+        let fixture = fixture(2.349);
+
+        let actual: Decimal =
+            serde_json::from_str(&serde_json::to_string(&fixture).unwrap()).unwrap();
+
+        let expected = Decimal::from(2.35);
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/forge_domain/src/file.rs
+++ b/crates/forge_domain/src/file.rs
@@ -83,3 +83,140 @@ impl FileStatus {
         Self { path, status }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    /// Reusable fixture for a `FileInfo` covering an arbitrary line range.
+    fn file_info_fixture(start_line: u64, end_line: u64, total_lines: u64) -> FileInfo {
+        FileInfo::new(start_line, end_line, total_lines, "abc123".to_string())
+    }
+
+    /// Reusable fixture for a `FileNode` used to exercise conversions.
+    fn file_node_fixture() -> super::super::node::FileNode {
+        super::super::node::FileNode {
+            file_path: "src/main.rs".to_string(),
+            content: "fn main() {}".to_string(),
+            hash: "deadbeef".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_file_info_new_sets_all_fields() {
+        let actual = FileInfo::new(0, 10, 10, "hash".to_string());
+
+        let expected = FileInfo {
+            start_line: 0,
+            end_line: 10,
+            total_lines: 10,
+            content_hash: "hash".to_string(),
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_is_partial_false_for_full_read() {
+        let fixture = file_info_fixture(0, 10, 10);
+
+        let actual = fixture.is_partial();
+
+        assert!(!actual);
+    }
+
+    #[test]
+    fn test_is_partial_true_when_starting_past_first_line() {
+        let fixture = file_info_fixture(1, 10, 10);
+
+        let actual = fixture.is_partial();
+
+        assert!(actual);
+    }
+
+    #[test]
+    fn test_is_partial_true_when_ending_before_last_line() {
+        let fixture = file_info_fixture(0, 5, 10);
+
+        let actual = fixture.is_partial();
+
+        assert!(actual);
+    }
+
+    #[test]
+    fn test_is_partial_false_for_empty_file() {
+        let fixture = file_info_fixture(0, 0, 0);
+
+        let actual = fixture.is_partial();
+
+        assert!(!actual);
+    }
+
+    #[test]
+    fn test_file_hash_from_file_node_drops_content() {
+        let fixture = file_node_fixture();
+
+        let actual = FileHash::from(fixture);
+
+        let expected = FileHash {
+            path: "src/main.rs".to_string(),
+            hash: "deadbeef".to_string(),
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_file_status_new_sets_all_fields() {
+        let actual = FileStatus::new("src/lib.rs".to_string(), SyncStatus::Modified);
+
+        let expected = FileStatus { path: "src/lib.rs".to_string(), status: SyncStatus::Modified };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_sync_status_ordering_follows_declaration_order() {
+        let fixture = vec![
+            SyncStatus::Failed,
+            SyncStatus::New,
+            SyncStatus::InSync,
+            SyncStatus::Deleted,
+            SyncStatus::Modified,
+        ];
+
+        let actual = {
+            let mut sorted = fixture;
+            sorted.sort();
+            sorted
+        };
+
+        let expected = vec![
+            SyncStatus::InSync,
+            SyncStatus::Modified,
+            SyncStatus::New,
+            SyncStatus::Deleted,
+            SyncStatus::Failed,
+        ];
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_file_serde_roundtrip() {
+        let fixture = File { path: "docs/readme.md".to_string(), is_dir: false };
+
+        let actual: File = serde_json::from_str(&serde_json::to_string(&fixture).unwrap()).unwrap();
+
+        let expected = fixture.clone();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_sync_status_serializes_as_variant_name() {
+        let fixture = SyncStatus::Deleted;
+
+        let actual = serde_json::to_string(&fixture).unwrap();
+
+        let expected = "\"Deleted\"".to_string();
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/forge_domain/src/model.rs
+++ b/crates/forge_domain/src/model.rs
@@ -104,3 +104,130 @@ impl std::str::FromStr for ModelId {
         Ok(ModelId(s.to_string()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    /// Reusable fixture producing a bare `Model` with default fields.
+    fn model_fixture() -> Model {
+        Model::new("gpt-4o")
+    }
+
+    #[test]
+    fn test_model_new_defaults_to_text_only() {
+        let actual = model_fixture();
+
+        let expected = Model {
+            id: ModelId::new("gpt-4o"),
+            name: None,
+            description: None,
+            context_length: None,
+            tools_supported: None,
+            supports_parallel_tool_calls: None,
+            supports_reasoning: None,
+            input_modalities: vec![InputModality::Text],
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_setters_strip_option_wraps_values() {
+        let actual = model_fixture()
+            .name("GPT-4o".to_string())
+            .context_length(128_000u64)
+            .tools_supported(true)
+            .supports_reasoning(false);
+
+        let expected = Model {
+            id: ModelId::new("gpt-4o"),
+            name: Some("GPT-4o".to_string()),
+            description: None,
+            context_length: Some(128_000),
+            tools_supported: Some(true),
+            supports_parallel_tool_calls: None,
+            supports_reasoning: Some(false),
+            input_modalities: vec![InputModality::Text],
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_model_id_new_and_as_str_roundtrip() {
+        let fixture = ModelId::new("claude-3");
+
+        let actual = fixture.as_str();
+
+        let expected = "claude-3";
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_model_id_from_str_matches_from_string() {
+        let actual = ModelId::from_str("anthropic/claude").unwrap();
+
+        let expected = ModelId::from("anthropic/claude".to_string());
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_model_id_displays_inner_string() {
+        let fixture = ModelId::new("o1-mini");
+
+        let actual = fixture.to_string();
+
+        let expected = "o1-mini".to_string();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_model_id_serializes_transparently() {
+        let fixture = ModelId::new("gemini-pro");
+
+        let actual = serde_json::to_string(&fixture).unwrap();
+
+        let expected = "\"gemini-pro\"".to_string();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_input_modality_serializes_lowercase() {
+        let fixture = vec![InputModality::Text, InputModality::Image];
+
+        let actual = serde_json::to_string(&fixture).unwrap();
+
+        let expected = "[\"text\",\"image\"]".to_string();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_input_modality_from_str_is_case_insensitive() {
+        let actual = InputModality::from_str("IMAGE").unwrap();
+
+        let expected = InputModality::Image;
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_deserialize_model_applies_default_input_modalities() {
+        let setup = r#"{"id":"gpt-4o","name":null,"description":null,"context_length":null,
+            "tools_supported":null,"supports_parallel_tool_calls":null,"supports_reasoning":null}"#;
+
+        let actual: Model = serde_json::from_str(setup).unwrap();
+
+        let expected = model_fixture();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_parameters_new_sets_tool_supported() {
+        let actual = Parameters::new(true).tool_supported;
+
+        let expected = true;
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/forge_eventsource/Cargo.toml
+++ b/crates/forge_eventsource/Cargo.toml
@@ -20,3 +20,4 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 futures-retry = "0.6"
 pin-utils = "0.1"
 rocket = "0.5.0"
+pretty_assertions.workspace = true

--- a/crates/forge_eventsource/src/retry.rs
+++ b/crates/forge_eventsource/src/retry.rs
@@ -118,3 +118,182 @@ pub const DEFAULT_RETRY: ExponentialBackoff = ExponentialBackoff::new(
     Some(Duration::from_secs(5)),
     None,
 );
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    /// Reusable error fixture; all policies ignore the error contents.
+    fn error_fixture() -> Error {
+        Error::StreamEnded
+    }
+
+    /// Reusable exponential backoff fixture starting at 100ms, doubling.
+    fn backoff_fixture() -> ExponentialBackoff {
+        ExponentialBackoff::new(Duration::from_millis(100), 2.0, None, None)
+    }
+
+    #[test]
+    fn test_exponential_first_retry_uses_start() {
+        let fixture = backoff_fixture();
+
+        let actual = fixture.retry(&error_fixture(), None);
+
+        let expected = Some(Duration::from_millis(100));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_exponential_multiplies_last_duration_by_factor() {
+        let fixture = backoff_fixture();
+
+        let actual = fixture.retry(&error_fixture(), Some((1, Duration::from_millis(100))));
+
+        let expected = Some(Duration::from_millis(200));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_exponential_clamps_to_max_duration() {
+        let fixture = ExponentialBackoff::new(
+            Duration::from_millis(100),
+            2.0,
+            Some(Duration::from_millis(150)),
+            None,
+        );
+
+        let actual = fixture.retry(&error_fixture(), Some((1, Duration::from_millis(100))));
+
+        let expected = Some(Duration::from_millis(150));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_exponential_stops_at_max_retries() {
+        let fixture = ExponentialBackoff::new(Duration::from_millis(100), 2.0, None, Some(3));
+
+        let actual = fixture.retry(&error_fixture(), Some((3, Duration::from_millis(100))));
+
+        let expected = None;
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_exponential_retries_below_max_retries() {
+        let fixture = ExponentialBackoff::new(Duration::from_millis(100), 2.0, None, Some(3));
+
+        let actual = fixture.retry(&error_fixture(), Some((2, Duration::from_millis(100))));
+
+        let expected = Some(Duration::from_millis(200));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_exponential_set_reconnection_time_raises_start_and_max() {
+        let mut fixture = ExponentialBackoff::new(
+            Duration::from_millis(100),
+            2.0,
+            Some(Duration::from_millis(150)),
+            Some(5),
+        );
+
+        fixture.set_reconnection_time(Duration::from_millis(400));
+        let actual = (fixture.start, fixture.max_duration, fixture.max_retries);
+
+        let expected = (
+            Duration::from_millis(400),
+            Some(Duration::from_millis(400)),
+            Some(5),
+        );
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_exponential_set_reconnection_time_keeps_larger_max() {
+        let mut fixture = ExponentialBackoff::new(
+            Duration::from_millis(100),
+            2.0,
+            Some(Duration::from_secs(5)),
+            None,
+        );
+
+        fixture.set_reconnection_time(Duration::from_millis(400));
+        let actual = (fixture.start, fixture.max_duration);
+
+        let expected = (Duration::from_millis(400), Some(Duration::from_secs(5)));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_constant_returns_same_delay_regardless_of_last_retry() {
+        let fixture = Constant::new(Duration::from_millis(250), None);
+
+        let actual = (
+            fixture.retry(&error_fixture(), None),
+            fixture.retry(&error_fixture(), Some((9, Duration::from_secs(60)))),
+        );
+
+        let expected = (
+            Some(Duration::from_millis(250)),
+            Some(Duration::from_millis(250)),
+        );
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_constant_stops_at_max_retries() {
+        let fixture = Constant::new(Duration::from_millis(250), Some(2));
+
+        let actual = fixture.retry(&error_fixture(), Some((2, Duration::from_millis(250))));
+
+        let expected = None;
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_constant_set_reconnection_time_replaces_delay() {
+        let mut fixture = Constant::new(Duration::from_millis(250), None);
+
+        fixture.set_reconnection_time(Duration::from_millis(900));
+        let actual = fixture.retry(&error_fixture(), None);
+
+        let expected = Some(Duration::from_millis(900));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_never_policy_never_retries() {
+        let mut fixture = Never;
+        fixture.set_reconnection_time(Duration::from_secs(1));
+
+        let actual = (
+            fixture.retry(&error_fixture(), None),
+            fixture.retry(&error_fixture(), Some((0, Duration::from_secs(1)))),
+        );
+
+        let expected = (None, None);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_default_retry_constant_values() {
+        let fixture = DEFAULT_RETRY;
+
+        let actual = (
+            fixture.start,
+            fixture.factor,
+            fixture.max_duration,
+            fixture.max_retries,
+        );
+
+        let expected = (
+            Duration::from_millis(300),
+            2.0,
+            Some(Duration::from_secs(5)),
+            None,
+        );
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/forge_repo/src/provider/retry.rs
+++ b/crates/forge_repo/src/provider/retry.rs
@@ -4,8 +4,14 @@ use forge_app::dto::openai::{Error, ErrorCode, ErrorResponse};
 use forge_config::RetryConfig;
 
 const TRANSPORT_ERROR_CODES: [&str; 3] = ["ERR_STREAM_PREMATURE_CLOSE", "ECONNRESET", "ETIMEDOUT"];
-const OPENAI_OVERLOADED_ERROR_CODE: &str = "server_is_overloaded";
+const OPENAI_RETRYABLE_ERROR_CODES: [&str; 2] = ["server_is_overloaded", "server_error"];
 
+/// Converts known transient provider failures into retryable domain errors.
+///
+/// # Arguments
+///
+/// * `error` - The provider error to classify.
+/// * `retry_config` - Configured retryable HTTP status codes.
 pub fn into_retry(error: anyhow::Error, retry_config: &RetryConfig) -> anyhow::Error {
     if let Some(code) = get_req_status_code(&error)
         .or(get_event_req_status_code(&error))
@@ -70,7 +76,7 @@ fn get_event_req_status_code(error: &anyhow::Error) -> Option<u16> {
 #[derive(Clone, Copy)]
 enum RetryableApiErrorCode {
     Transport,
-    OpenAIOverloaded,
+    OpenAIServer,
 }
 
 impl RetryableApiErrorCode {
@@ -81,7 +87,7 @@ impl RetryableApiErrorCode {
 
         match self {
             RetryableApiErrorCode::Transport => TRANSPORT_ERROR_CODES.contains(&code),
-            RetryableApiErrorCode::OpenAIOverloaded => code == OPENAI_OVERLOADED_ERROR_CODE,
+            RetryableApiErrorCode::OpenAIServer => OPENAI_RETRYABLE_ERROR_CODES.contains(&code),
         }
     }
 }
@@ -117,9 +123,7 @@ fn is_openai_overloaded_error(error: &anyhow::Error) -> bool {
     error
         .downcast_ref::<Error>()
         .is_some_and(|error| match error {
-            Error::Response(error) => {
-                has_error_code(error, RetryableApiErrorCode::OpenAIOverloaded)
-            }
+            Error::Response(error) => has_error_code(error, RetryableApiErrorCode::OpenAIServer),
             _ => false,
         })
 }
@@ -149,6 +153,7 @@ fn is_event_transport_error(error: &anyhow::Error) -> bool {
 mod tests {
     use anyhow::anyhow;
     use forge_app::dto::openai::{Error, ErrorCode, ErrorResponse};
+    use pretty_assertions::assert_eq;
 
     use super::*;
 
@@ -336,24 +341,26 @@ mod tests {
     }
 
     #[test]
-    fn test_openai_server_overloaded_error_is_retryable() {
-        let retry_config = fixture_retry_config(vec![]);
+    fn test_openai_server_errors_are_retryable() {
+        let fixture = fixture_retry_config(vec![]);
 
-        let error = anyhow::Error::from(Error::Response(
-            ErrorResponse::default()
-                .code(ErrorCode::String("server_is_overloaded".to_string()))
-                .message(
-                    "Our servers are currently overloaded. Please try again later.".to_string(),
-                ),
-        ));
+        for code in OPENAI_RETRYABLE_ERROR_CODES {
+            let error = anyhow::Error::from(Error::Response(
+                ErrorResponse::default().code(ErrorCode::String(code.to_string())),
+            ));
+            let actual = is_retryable(into_retry(error, &fixture));
+            let expected = true;
 
-        assert!(is_retryable(into_retry(error, &retry_config)));
+            assert_eq!(actual, expected, "{code} should be retryable");
+        }
 
         let error = anyhow::Error::from(Error::Response(
             ErrorResponse::default().code(ErrorCode::String("rate_limit".to_string())),
         ));
+        let actual = is_retryable(into_retry(error, &fixture));
+        let expected = false;
 
-        assert!(!is_retryable(into_retry(error, &retry_config)));
+        assert_eq!(actual, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Treat OpenAI `server_error` responses as transient failures while expanding unit coverage across release, configuration, domain, event-source, and provider retry logic.

## Changes
- Classify both `server_is_overloaded` and `server_error` provider responses as retryable
- Add unit coverage for release matrix invariants and JSON conversion
- Test decimal conversion, comparison, serialization, and rounding behavior
- Cover file metadata, sync status, model defaults, identifiers, and serialization
- Verify exponential, constant, never, and default event-source retry policies
- Add `pretty_assertions` as a test dependency where needed

## Key Implementation Details
OpenAI retry classification now uses a shared list of retryable server error codes instead of checking only the overloaded-server code. `MatrixEntry` also derives `Debug`, `PartialEq`, and `Eq` to support direct assertions in the new tests.

## Testing
Run the unit tests added in:
- `crates/forge_ci/src/release_matrix.rs`
- `crates/forge_config/src/decimal.rs`
- `crates/forge_domain/src/file.rs`
- `crates/forge_domain/src/model.rs`
- `crates/forge_eventsource/src/retry.rs`
- `crates/forge_repo/src/provider/retry.rs`