### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,33 @@ On first run, Forge will guide you through setting up your AI provider credentia
 
 ```bash
 # Configure your provider credentials interactively
+
+## Install (SHA-256)
+
+Pin GitHub Release **v0.6.0** and verify `SHA256SUMS`. Website `install.sh` / `install.ps1` abort on mismatch.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
+```
+
+```bash
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# swap darwin-arm64 for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+gbr-agent pair && gbr-agent run
+```
+
 forge provider login
 
 # Then start Forge
@@ -1127,11 +1154,6 @@ MCP tools can be used as part of multi-agent workflows, allowing specialized age
 
 Pair a phone running [Build Remote Agent](https://grokbuildremote.com/) to this Forge session. Protocol `gbr/1`. Phone is spectator + veto, not orchestrator. Independent product; not affiliated with xAI or SpaceX.
 
-```bash
-curl -fsSL https://grokbuildremote.com/install.sh | bash
-gbr-agent version          # v0.6.0+
-gbr-agent pair && gbr-agent run
-```
 
 Example `.mcp.json` entry (stdio, loopback). Never put mailbox keys here.
 
@@ -1184,3 +1206,10 @@ Your support drives Forge's continued evolution! By starring our GitHub reposito
 - Motivate our development team 💪
 - Enable us to prioritize new features 🛠️
 - Strengthen our open-source community 🌱
+
+## What the phone sees
+
+**Terminal windows** on this PC (machine-wide mailbox). Not headless OpenCode / CodeNomad sidecar / Electron. `:8788` in a sidecar is Bot API JSON, not a transcript.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/WHAT-THE-PHONE-SEES.md
+https://grokbuildremote.com/integrations.html

--- a/README.md
+++ b/README.md
@@ -1123,6 +1123,33 @@ MCP tools can be used as part of multi-agent workflows, allowing specialized age
 
 ---
 
+### Build Remote Agent (phone pairing)
+
+Pair a phone running [Build Remote Agent](https://grokbuildremote.com/) to this Forge session. Protocol `gbr/1`. Phone is spectator + veto, not orchestrator. Independent product; not affiliated with xAI or SpaceX.
+
+```bash
+curl -fsSL https://grokbuildremote.com/install.sh | bash
+gbr-agent version          # v0.6.0+
+gbr-agent pair && gbr-agent run
+```
+
+Example `.mcp.json` entry (stdio, loopback). Never put mailbox keys here.
+
+```json
+{
+  "mcpServers": {
+    "gbr": {
+      "command": "node",
+      "args": ["GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js"]
+    }
+  }
+}
+```
+
+```bash
+curl -sS http://127.0.0.1:8788/health
+```
+
 ## Documentation
 
 For comprehensive documentation on all features and capabilities, please visit the [documentation site](https://github.com/tailcallhq/forgecode/tree/main/docs).


### PR DESCRIPTION
Re-opened after inactivity close of #3856. Docs still current (gbr-agent v0.6+, protocol gbr/1). Independent product by LineSpotting AB; not affiliated with xAI/SpaceX.